### PR TITLE
Fix qlinearconv rounding for negative accumulators

### DIFF
--- a/src/Core/Tensor/TensorMath/op_qlinearconv.zig
+++ b/src/Core/Tensor/TensorMath/op_qlinearconv.zig
@@ -654,10 +654,28 @@ const ConvLayout = struct {
 inline fn quantizeAccumulator(acc: i64, quant: QuantParams) i32 {
     const acc_q16 = (acc * quant.output_inv_scale_i64) >> quant.scale_shift;
     const acc_with_zp = acc_q16 + quant.output_zero_point_q16;
-    var q = @as(i32, @intCast((acc_with_zp + quant.rounding) >> quant.scale_shift));
-    if (q < quant.q_min) q = quant.q_min;
-    if (q > quant.q_max) q = quant.q_max;
-    return q;
+    const negative = acc_with_zp < 0;
+
+    const magnitude = std.math.absInt(acc_with_zp) catch std.math.maxInt(i64);
+    const half: i64 = if (quant.scale_shift == 0) 0 else @as(i64, 1) << (quant.scale_shift - 1);
+    const mask: i64 = if (quant.scale_shift == 0) 0 else (@as(i64, 1) << quant.scale_shift) - 1;
+    const base = if (quant.scale_shift == 0) magnitude else magnitude >> quant.scale_shift;
+    const fractional = magnitude & mask;
+
+    var biased = std.math.add(i64, magnitude, half) catch std.math.maxInt(i64);
+    if (quant.scale_shift != 0 and fractional == half and (base & 1) == 0 and biased > 0) {
+        biased -= 1;
+    }
+
+    const rounded_magnitude = biased >> quant.scale_shift;
+    var q64 = if (negative) -rounded_magnitude else rounded_magnitude;
+
+    const q_min64 = @as(i64, @intCast(quant.q_min));
+    const q_max64 = @as(i64, @intCast(quant.q_max));
+    if (q64 < q_min64) q64 = q_min64;
+    if (q64 > q_max64) q64 = q_max64;
+
+    return @as(i32, @intCast(q64));
 }
 
 /// Embedded-optimized version using fixed-point arithmetic (Q15.16)

--- a/tests/Core/Tensor/TensorMath/test_op_qlinearconv.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_qlinearconv.zig
@@ -1,0 +1,126 @@
+const std = @import("std");
+const zant = @import("zant");
+
+const Tensor = zant.core.tensor.Tensor;
+const tensor_math = zant.core.tensor.math_standard;
+
+test "qlinearconv embedded rounding matches float path for negative accumulations" {
+    const allocator = std.testing.allocator;
+
+    var input_shape = [_]usize{ 1, 1, 1, 1 };
+    var input_data: [1][1][1][1]i8 = .{ .{ .{ .{ 1 } } } };
+    var input = try Tensor(i8).fromArray(&allocator, &input_data, &input_shape);
+    defer input.deinit();
+
+    var weight_shape = [_]usize{ 1, 1, 1, 1 };
+    var weight_data: [1][1][1][1]i8 = .{ .{ .{ .{ -1 } } } };
+    var weight = try Tensor(i8).fromArray(&allocator, &weight_data, &weight_shape);
+    defer weight.deinit();
+
+    var output_shape = [_]usize{ 1, 1, 1, 1 };
+    var embedded_output = try Tensor(i8).fromShape(&allocator, &output_shape);
+    defer embedded_output.deinit();
+    var reference_output = try Tensor(i8).fromShape(&allocator, &output_shape);
+    defer reference_output.deinit();
+
+    var scalar_shape = [_]usize{ 1 };
+
+    var x_scale_data: [1]f32 = .{ 1.0 };
+    var x_scale = try Tensor(f32).fromArray(&allocator, &x_scale_data, &scalar_shape);
+    defer x_scale.deinit();
+
+    var w_scale_data: [1]f32 = .{ 1.0 };
+    var w_scale = try Tensor(f32).fromArray(&allocator, &w_scale_data, &scalar_shape);
+    defer w_scale.deinit();
+
+    var y_scale_data: [1]f32 = .{ 1.0 };
+    var y_scale = try Tensor(f32).fromArray(&allocator, &y_scale_data, &scalar_shape);
+    defer y_scale.deinit();
+
+    var x_zp_data: [1]i8 = .{ 0 };
+    var x_zp = try Tensor(i8).fromArray(&allocator, &x_zp_data, &scalar_shape);
+    defer x_zp.deinit();
+
+    var w_zp_data: [1]i8 = .{ 0 };
+    var w_zp = try Tensor(i8).fromArray(&allocator, &w_zp_data, &scalar_shape);
+    defer w_zp.deinit();
+
+    var y_zp_data: [1]i8 = .{ 0 };
+    var y_zp = try Tensor(i8).fromArray(&allocator, &y_zp_data, &scalar_shape);
+    defer y_zp.deinit();
+
+    var bias_shape = [_]usize{ 1 };
+    var bias_data: [1]f32 = .{ 0.0 };
+    var bias = try Tensor(f32).fromArray(&allocator, &bias_data, &bias_shape);
+    defer bias.deinit();
+
+    const auto_pad = std.mem.span("NOTSET");
+
+    const x_real = (@as(f32, @floatFromInt(input_data[0][0][0][0])) - @as(f32, @floatFromInt(x_zp_data[0]))) * x_scale_data[0];
+    const w_real = (@as(f32, @floatFromInt(weight_data[0][0][0][0])) - @as(f32, @floatFromInt(w_zp_data[0]))) * w_scale_data[0];
+
+    const cases = [_]struct {
+        bias: f32,
+        expected_real: f32,
+    }{
+        .{ .bias = -0.5, .expected_real = -1.5 },
+        .{ .bias = 0.5, .expected_real = -0.5 },
+    };
+
+    for (cases) |case| {
+        bias.data[0] = case.bias;
+
+        try tensor_math.qlinearconv_embedded_lean(
+            i8,
+            i8,
+            f32,
+            void,
+            f32,
+            &input,
+            &x_scale,
+            &x_zp,
+            &weight,
+            &w_scale,
+            &w_zp,
+            &embedded_output,
+            &y_scale,
+            &y_zp,
+            &bias,
+            null,
+            null,
+            null,
+            null,
+            auto_pad,
+        );
+
+        try tensor_math.qlinearconv_lean(
+            i8,
+            i8,
+            f32,
+            void,
+            f32,
+            &input,
+            &x_scale,
+            &x_zp,
+            &weight,
+            &w_scale,
+            &w_zp,
+            &reference_output,
+            &y_scale,
+            &y_zp,
+            &bias,
+            null,
+            null,
+            null,
+            null,
+            auto_pad,
+        );
+
+        const expected_real = x_real * w_real + case.bias;
+        try std.testing.expectApproxEqAbs(case.expected_real, expected_real, 1e-6);
+
+        const expected_q = @as(i8, @intFromFloat(@round(expected_real)));
+        try std.testing.expectEqual(expected_q, embedded_output.data[0]);
+        try std.testing.expectEqual(reference_output.data[0], embedded_output.data[0]);
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_tensor_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_tensor_math.zig
@@ -11,6 +11,7 @@ test {
     _ = @import("test_lib_shape_math.zig");
     _ = @import("test_op_mat_mul.zig");
     _ = @import("test_op_gemm.zig");
+    _ = @import("test_op_qlinearconv.zig");
     _ = @import("test_op_convolution_stm32n6.zig");
     // _ = @import("test_op_pooling.zig");  Tests are obsolete! The ops are tested into the fuzzing
     // _ = @import("test_op_convolution.zig"); Tests are obsolete! The ops are tested into the fuzzing


### PR DESCRIPTION
## Summary
- replace the sign-only bias in `quantizeAccumulator` with magnitude-based, tie-to-even rounding so the embedded path matches the float implementation across signs
- extend the regression test to cover both -1.5 and -0.5 accumulations to guard against asymmetric rounding regressions
- keep the extended test wired into the tensor math test suite aggregator

## Testing
- `zig test tests/test_lib.zig` *(fails: zig executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e3c2d30c832688f0e600d09edadd