### PR TITLE
Example: Nicla-SmartTrashCollector (Nicla Vision 5-class waste)

### DIFF
--- a/examples/Nicla-SmartTrashCollector/.gitignore
+++ b/examples/Nicla-SmartTrashCollector/.gitignore
@@ -1,0 +1,5 @@
+build/
+*.bin
+*.elf
+*.hex
+ZantLib/src/cortex-m7/libzant.a

--- a/examples/Nicla-SmartTrashCollector/Nicla-SmartTrashCollector.ino
+++ b/examples/Nicla-SmartTrashCollector/Nicla-SmartTrashCollector.ino
@@ -1,0 +1,464 @@
+#include <Arduino.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+#include "lib_zant.h"
+#include "camera.h"
+#include "gc2145.h"
+
+// ----- LED pins (Nicla Vision) -----
+#ifndef LEDR
+#define LEDR 23
+#define LEDG 24
+#define LEDB 25
+#endif
+
+// If colors look inverted, flip this
+static const bool LED_ACTIVE_HIGH = true;
+
+// Discrete (ON/OFF) driver
+static inline void setRGBDiscrete(bool r, bool g, bool b) {
+  auto drive = [](int pin, bool on){
+    bool level = LED_ACTIVE_HIGH ? on : !on;
+    digitalWrite(pin, level ? HIGH : LOW);
+  };
+  drive(LEDR, r);
+  drive(LEDG, g);
+  drive(LEDB, b);
+}
+
+enum Cat : uint8_t { GENERAL=0, GLASS=1, ORGANIC=2, PAPER=3, PLASTIC=4 };
+
+// Map to 5 distinct discrete colors (no PWM)
+static void showCategory(uint8_t cat) {
+  switch (cat) {
+    case GENERAL: setRGBDiscrete(true,  true,  false); break; // yellow  (R+G)
+    case GLASS:   setRGBDiscrete(false, false, true ); break; // blue    (B)
+    case ORGANIC:   setRGBDiscrete(false, true,  false); break; // green   (G)
+    case PAPER: setRGBDiscrete(true,  false, false); break; // red     (R) ~ brown-ish
+    case PLASTIC: setRGBDiscrete(true,  true,  true ); break; // white   (R+G+B) ~ grey
+    default:      setRGBDiscrete(false, false, false); break; // off
+  }
+}
+
+// ================== Config ==================
+#define BAUD                 921600
+#define THR                  0.60f
+#define RGB565_IS_MSB_FIRST  1   // 1: big-endian (MSB-first), 0: little-endian
+#define STREAM_TO_PC         0   // 1: stream binario compatibile con viewer Python, 0: solo log
+
+// ================== Modello (NCHW) ==================
+static const uint32_t N=1, C=3, H=96, W=96;     // input RGB channels-first
+static const uint32_t CLASSES=5;
+static uint32_t inputShape[4] = {N, C, H, W};   // NCHW
+
+// ================== Buffers ==================
+// Input normalizzato 0..1 (float). ~108 KB
+alignas(32) static float gInput[N*C*H*W];
+// Opzionale: anteprima in GRAY8 (non normalizzata, solo preview)
+static uint8_t gGray8[W*H];
+
+// ================== Camera ==================
+GC2145  sensor;
+Camera  cam(sensor);
+FrameBuffer fb;
+
+// ================== ZANT hooks (deboli) ==================
+extern "C" void setLogFunction(void (*logger)(char*)) __attribute__((weak));
+extern "C" void zant_free_result(float*) __attribute__((weak));
+extern "C" void zant_init_weights_io(void) __attribute__((weak));
+extern "C" void zant_set_weights_base_address(const uint8_t*) __attribute__((weak));
+extern "C" void zant_register_weight_callback(int (*cb)(size_t,uint8_t*,size_t)) __attribute__((weak));
+extern "C" __attribute__((used)) const uint8_t* flash_weights_base=(const uint8_t*)0x90000000u;
+
+// ================== QSPI / HAL (STM32H747) ==================
+extern "C" {
+  #ifndef STM32H747xx
+  #define STM32H747xx
+  #endif
+  #ifndef HAL_QSPI_MODULE_ENABLED
+  #define HAL_QSPI_MODULE_ENABLED
+  #endif
+  #include "stm32h7xx_hal.h"
+  #include "stm32h7xx_hal_qspi.h"
+}
+static QSPI_HandleTypeDef hqspi;
+
+// Comandi tipici NOR esterna (verifica con il tuo chip se servono diversi)
+static const uint8_t CMD_RDSR1 = 0x05;
+static const uint8_t CMD_RDSR2 = 0x35;
+static const uint8_t CMD_WRSR  = 0x01;
+static const uint8_t CMD_WREN  = 0x06;
+static const uint8_t CMD_READ_QO = 0x6B;   // Quad Output Fast Read
+
+extern "C" void HAL_QSPI_MspInit(QSPI_HandleTypeDef* h) {
+  if (h->Instance != QUADSPI) return;
+  __HAL_RCC_GPIOB_CLK_ENABLE();
+  __HAL_RCC_GPIOD_CLK_ENABLE();
+  __HAL_RCC_GPIOG_CLK_ENABLE();
+  __HAL_RCC_QSPI_CLK_ENABLE();
+
+  GPIO_InitTypeDef G = {0};
+  // PB2: CLK
+  G.Pin = GPIO_PIN_2; G.Mode = GPIO_MODE_AF_PP; G.Pull = GPIO_NOPULL;
+  G.Speed = GPIO_SPEED_FREQ_VERY_HIGH; G.Alternate = GPIO_AF9_QUADSPI;
+  HAL_GPIO_Init(GPIOB, &G);
+
+  // PG6: nCS
+  G.Pin = GPIO_PIN_6; G.Alternate = GPIO_AF10_QUADSPI;
+  HAL_GPIO_Init(GPIOG, &G);
+
+  // PD11..PD14: IO0..IO3
+  G.Pin = GPIO_PIN_11 | GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14;
+  G.Alternate = GPIO_AF9_QUADSPI;
+  HAL_GPIO_Init(GPIOD, &G);
+}
+
+static HAL_StatusTypeDef rd_sr(QSPI_HandleTypeDef* h, uint8_t cmd, uint8_t* v){
+  QSPI_CommandTypeDef c = {0};
+  c.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+  c.Instruction     = cmd;
+  c.AddressMode     = QSPI_ADDRESS_NONE;
+  c.DataMode        = QSPI_DATA_1_LINE;
+  c.NbData          = 1;
+  if (HAL_QSPI_Command(h, &c, HAL_MAX_DELAY) != HAL_OK) return HAL_ERROR;
+  return HAL_QSPI_Receive(h, v, HAL_MAX_DELAY);
+}
+
+static HAL_StatusTypeDef wren(QSPI_HandleTypeDef* h){
+  QSPI_CommandTypeDef c = {0};
+  c.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+  c.Instruction     = CMD_WREN;
+  c.AddressMode     = QSPI_ADDRESS_NONE;
+  c.DataMode        = QSPI_DATA_NONE;
+  return HAL_QSPI_Command(h, &c, HAL_MAX_DELAY);
+}
+
+static HAL_StatusTypeDef wait_wip_clear(QSPI_HandleTypeDef* h, uint32_t to_ms){
+  uint32_t t0 = millis();
+  for(;;){
+    uint8_t sr1 = 0;
+    if (rd_sr(h, CMD_RDSR1, &sr1) != HAL_OK) return HAL_ERROR;
+    if ((sr1 & 0x01) == 0) return HAL_OK;    // WIP=0
+    if ((millis() - t0) > to_ms) return HAL_TIMEOUT;
+    delay(1);
+  }
+}
+
+static HAL_StatusTypeDef enable_quad(QSPI_HandleTypeDef* h){
+  uint8_t sr1=0, sr2=0;
+  if (rd_sr(h, CMD_RDSR1, &sr1) != HAL_OK) return HAL_ERROR;
+  if (rd_sr(h, CMD_RDSR2, &sr2) != HAL_OK) return HAL_ERROR;
+  if (sr2 & 0x02) return HAL_OK; // QE già attivo
+
+  if (wren(h) != HAL_OK) return HAL_ERROR;
+
+  QSPI_CommandTypeDef c = {0};
+  c.InstructionMode = QSPI_INSTRUCTION_1_LINE;
+  c.Instruction     = CMD_WRSR;
+  c.AddressMode     = QSPI_ADDRESS_NONE;
+  c.DataMode        = QSPI_DATA_1_LINE;
+  c.NbData          = 2;
+
+  uint8_t buf[2] = { sr1, (uint8_t)(sr2 | 0x02) };
+  if (HAL_QSPI_Command(h, &c, HAL_MAX_DELAY) != HAL_OK) return HAL_ERROR;
+  if (HAL_QSPI_Transmit(h, buf, HAL_MAX_DELAY) != HAL_OK) return HAL_ERROR;
+  if (wait_wip_clear(h, 500) != HAL_OK) return HAL_ERROR;
+
+  if (rd_sr(h, CMD_RDSR2, &sr2) != HAL_OK) return HAL_ERROR;
+  return (sr2 & 0x02) ? HAL_OK : HAL_ERROR;
+}
+
+static HAL_StatusTypeDef qspi_init_16mb(QSPI_HandleTypeDef* h){
+  h->Instance               = QUADSPI;
+  h->Init.ClockPrescaler    = 7;  // f_qspi = f_ahb/(Presc+1)
+  h->Init.FifoThreshold     = 4;
+  h->Init.SampleShifting    = QSPI_SAMPLE_SHIFTING_NONE;
+  h->Init.FlashSize         = 23; // 2^23 -> 8MB; per 16MB usare 24. Nicla tipica è 16MB -> 24
+  h->Init.FlashSize         = 24; // forza 16MB
+  h->Init.ChipSelectHighTime= QSPI_CS_HIGH_TIME_2_CYCLE;
+  h->Init.ClockMode         = QSPI_CLOCK_MODE_0;
+  h->Init.FlashID           = QSPI_FLASH_ID_1;
+  h->Init.DualFlash         = QSPI_DUALFLASH_DISABLE;
+  return HAL_QSPI_Init(h);
+}
+
+static HAL_StatusTypeDef qspi_enter_mmap(QSPI_HandleTypeDef* h){
+  QSPI_CommandTypeDef c = {0};
+  c.InstructionMode  = QSPI_INSTRUCTION_1_LINE;
+  c.Instruction      = CMD_READ_QO;
+  c.AddressMode      = QSPI_ADDRESS_1_LINE;
+  c.AddressSize      = QSPI_ADDRESS_24_BITS;
+  c.Address          = 0x000000;
+  c.AlternateByteMode= QSPI_ALTERNATE_BYTES_NONE;
+  c.DataMode         = QSPI_DATA_4_LINES;
+  c.DummyCycles      = 8; // tipico per fast read quad
+  QSPI_MemoryMappedTypeDef mm = {0};
+  mm.TimeOutActivation = QSPI_TIMEOUT_COUNTER_DISABLE;
+  mm.TimeOutPeriod     = 0;
+  return HAL_QSPI_MemoryMapped(h, &c, &mm);
+}
+
+static int qspi_xip_read(size_t off, uint8_t* buf, size_t sz) {
+  if (!buf || !flash_weights_base) return -1;
+  memcpy(buf, flash_weights_base + off, sz);
+  return 0;
+}
+static void attach_weights_io() {
+  if (zant_init_weights_io) zant_init_weights_io();
+  if (zant_set_weights_base_address)      zant_set_weights_base_address(flash_weights_base);
+  else if (zant_register_weight_callback) zant_register_weight_callback(qspi_xip_read);
+}
+
+// ================== Logger ==================
+static inline bool streaming() { return STREAM_TO_PC != 0; }
+
+static void myLogger(char* msg) {
+  if (streaming()) return; // niente log quando si streamma binario
+  Serial.print("[ZANT] ");
+  if (msg) Serial.println(msg);
+  else     Serial.println("(null)");
+}
+static void mySilentLogger(char*) { /* no-op quando si streamma */ }
+
+// // ================== COCO80 labels ==================
+// static const char* COCO80[CLASSES] = {
+//   "general", "glass", "organic", "paper", "plastic"
+// };
+
+// ================== Helpers colore ==================
+static inline uint16_t load_rgb565_BE(const uint8_t* S2, int idx) {
+  return (uint16_t)((S2[2*idx] << 8) | S2[2*idx + 1]);
+}
+static inline uint16_t load_rgb565_LE(const uint8_t* S2, int idx) {
+  return (uint16_t)((S2[2*idx + 1] << 8) | S2[2*idx]);
+}
+static inline void rgb565_to_rgb888_u16(uint16_t v, uint8_t &R, uint8_t &G, uint8_t &B){
+  uint8_t r5=(v>>11)&0x1F, g6=(v>>5)&0x3F, b5=v&0x1F;
+  R=(uint8_t)((r5<<3)|(r5>>2));
+  G=(uint8_t)((g6<<2)|(g6>>4));
+  B=(uint8_t)((b5<<3)|(b5>>2));
+}
+static inline uint8_t clamp_u8(float x){
+  if (x <= 0.f)   return 0;
+  if (x >= 255.f) return 255;
+  return (uint8_t)lrintf(x);
+}
+static inline int clampi(int v, int lo, int hi){
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+// ================== Resize → NCHW + Gray ==================
+// Output gInput (NCHW): float normalizzato [0,1]
+static void resize_rgb565_to_96x96_rgbNCHW_and_gray_NEAREST(
+    const uint8_t* src, int sw, int sh,
+    float* __restrict dst_f, uint8_t* __restrict dst_gray)
+{
+  const float sx = (float)sw / (float)W;
+  const float sy = (float)sh / (float)H;
+  const float inv255 = 1.0f / 255.0f;
+
+  const int plane = (int)(H*W);
+  float* __restrict dstR = dst_f + 0*plane;
+  float* __restrict dstG = dst_f + 1*plane;
+  float* __restrict dstB = dst_f + 2*plane;
+
+  for (int y = 0; y < (int)H; ++y) {
+    int ys = clampi((int)floorf((y + 0.5f) * sy), 0, sh - 1);
+    for (int x = 0; x < (int)W; ++x) {
+      int xs = clampi((int)floorf((x + 0.5f) * sx), 0, sw - 1);
+      int si = ys * sw + xs;
+
+      uint16_t v = RGB565_IS_MSB_FIRST ? load_rgb565_BE(src, si)
+                                       : load_rgb565_LE(src, si);
+      uint8_t r,g,b; rgb565_to_rgb888_u16(v, r,g,b);
+
+      const int di = y*W + x;
+      dstR[di] = (float)r * inv255;
+      dstG[di] = (float)g * inv255;
+      dstB[di] = (float)b * inv255;
+
+      // Gray solo per preview (0..255)
+      gGray8[di] = clamp_u8(0.299f*r + 0.587f*g + 0.114f*b);
+    }
+  }
+}
+
+// ================== softmax + top1 ==================
+// static void softmax_vec(const float* in, int n, float* out){
+//   float m = -INFINITY;
+//   for (int i=0;i<n;++i) if (isfinite(in[i]) && in[i]>m) m=in[i];
+//   float s = 0.f;
+//   for (int i=0;i<n;++i){
+//     float z = isfinite(in[i]) ? (in[i]-m) : -50.f;
+//     float e = expf(z);
+//     out[i] = e; s += e;
+//   }
+//   if (s <= 0.f) {
+//     float u = 1.0f / (float)n;
+//     for (int i=0;i<n;++i) out[i] = u;
+//   } else {
+//     float inv = 1.0f / s;
+//     for (int i=0;i<n;++i) out[i] *= inv;
+//   }
+// }
+// static inline void top1(const float* p,int n,int* idx,float* val){
+//   int k=0; float b=-1.f;
+//   for (int i=0;i<n;++i){ if (p[i]>b){ b=p[i]; k=i; } }
+//   *idx=k; *val=b;
+// }
+
+static inline uint8_t argmax5(const float* a) {
+  uint8_t k=0; float m=a[0];
+  for (uint8_t i=1;i<5;i++) if (a[i] > m) { m=a[i]; k=i; }
+  return k;
+}
+
+static inline void softmax5(const float* z, float* p){
+  float m=z[0]; for(int i=1;i<5;i++) if(z[i]>m) m=z[i];
+  float s=0.f;  for(int i=0;i<5;i++){ p[i]=expf(z[i]-m); s+=p[i]; }
+  float inv = s>0.f? 1.f/s : 0.2f; for(int i=0;i<5;i++) p[i]*=inv;
+}
+
+// ================== CRC32 (Arduino-like) ==================
+static uint32_t crc32_arduino(const uint8_t* data, size_t len){
+  uint32_t crc = 0xFFFFFFFFu;
+  for (size_t i=0;i<len;++i){
+    crc ^= (uint32_t)data[i];
+    for (int b=0;b<8;++b){
+      if (crc & 1u) crc = (crc >> 1) ^ 0xEDB88320u;
+      else          crc >>= 1;
+    }
+  }
+  return ~crc;
+}
+
+// ================== Serial frame (FRME) ==================
+static const uint8_t MAGIC[4] = {'F','R','M','E'};
+static uint16_t g_seq = 0;
+
+static inline void put_le16(uint8_t* p, uint16_t v){ p[0] = (uint8_t)(v & 0xFF); p[1] = (uint8_t)(v >> 8); }
+static inline void put_le32(uint8_t* p, uint32_t v){ p[0] = (uint8_t)(v & 0xFF); p[1] = (uint8_t)((v>>8)&0xFF); p[2] = (uint8_t)((v>>16)&0xFF); p[3] = (uint8_t)((v>>24)&0xFF); }
+
+static void send_frame_gray_FRME(uint16_t w, uint16_t h, uint8_t cls, uint16_t prob_x1000, uint16_t ms_x10, const uint8_t* gray){
+  const uint32_t payload_len = (uint32_t)w * (uint32_t)h;
+  const uint32_t crc = crc32_arduino(gray, payload_len);
+
+  uint8_t hdr[20];
+  memcpy(hdr, MAGIC, 4);
+  hdr[4] = 1; // version
+  put_le16(&hdr[5], g_seq);
+  put_le16(&hdr[7], w);
+  put_le16(&hdr[9], h);
+  hdr[11] = cls;
+  put_le16(&hdr[12], prob_x1000);
+  put_le16(&hdr[14], ms_x10);
+  put_le32(&hdr[16], payload_len);
+
+  Serial.write(hdr, sizeof(hdr));
+  Serial.write(gray, payload_len);
+
+  uint8_t cbuf[4];
+  put_le32(cbuf, crc);
+  Serial.write(cbuf, 4);
+
+  g_seq++;
+}
+
+// ================== Setup ==================
+void setup(){
+  pinMode(LEDR, OUTPUT); pinMode(LEDG, OUTPUT); pinMode(LEDB, OUTPUT);
+  setRGBDiscrete(false,false,false);
+
+  Serial.begin(BAUD);
+  while (Serial.available()) Serial.read();
+
+  // Logger: silenzioso se streammo binario
+  if (setLogFunction) {
+    if (streaming()) setLogFunction(mySilentLogger);
+    else             setLogFunction(myLogger);
+  }
+
+  // ---- QSPI in Memory-Mapped Mode (XIP) ----
+  if (qspi_init_16mb(&hqspi) != HAL_OK) {
+    if (!streaming()) Serial.println("[ZANT] QSPI init FAILED");
+  } else if (enable_quad(&hqspi) != HAL_OK) {
+    if (!streaming()) Serial.println("[ZANT] QSPI enable QUAD FAILED");
+  } else if (qspi_enter_mmap(&hqspi) != HAL_OK) {
+    if (!streaming()) Serial.println("[ZANT] QSPI MMAP FAILED");
+  } else {
+    if (!streaming()) Serial.println("[ZANT] QSPI MMAP OK @0x90000000");
+  }
+  attach_weights_io();
+
+  // ---- Camera ----
+  cam.begin(CAMERA_R160x120, CAMERA_RGB565, 30);
+
+  if (!streaming()) {
+    Serial.println("[ZANT] Ready (NCHW 1x3x96x96, normalized 0..1).");
+  }
+}
+
+// ================== Loop ==================
+void loop(){
+  if (cam.grabFrame(fb, 3000) != 0){
+    if (!streaming()) Serial.println("[ZANT] camera timeout");
+    delay(5);
+    return;
+  }
+  const uint8_t* buf = fb.getBuffer();
+
+  resize_rgb565_to_96x96_rgbNCHW_and_gray_NEAREST(buf, 160, 120, gInput, gGray8);
+
+  // Inference
+  float* out_raw = nullptr;
+  unsigned long t0 = micros();
+  int rc = predict(gInput, inputShape, 4, &out_raw);
+  unsigned long t1 = micros();
+
+  float ms_f = (t1 - t0) / 1000.0f;
+  uint16_t ms_x10 = (uint16_t) (ms_f * 10.0f + 0.5f);
+
+  if (rc != 0 || !out_raw) {
+    if (!streaming()) {
+      Serial.print("[ZANT] predict() rc=");
+      Serial.println(rc);
+    }
+    delay(5);
+    return;
+  }
+
+  // --- choose class + probability (5-logit model) ---
+  uint8_t cls = argmax5(out_raw);   // argmax on raw logits
+
+  float p5[5];
+  softmax5(out_raw, p5);            // full 5-way softmax
+  float prob = p5[cls];
+  if (prob < 0.f) prob = 0.f; else if (prob > 1.f) prob = 1.f;
+  uint16_t prob_x1000 = (uint16_t)lrintf(prob * 1000.0f);
+
+  // --- LED feedback ---
+  showCategory(cls);
+
+  // --- stream or log ---
+  if (streaming()) {
+    send_frame_gray_FRME(W, H, cls, prob_x1000, ms_x10, gGray8);
+  } else {
+    // static const char* NAMES[5] = { "Plastic","Paper","Glass","Organic","General" };
+    static const char* NAMES[5] = { "General","Glass","Organic","Paper","Plastic" };
+
+    Serial.print("[Waste Selector]: idx="); Serial.print(cls);
+    Serial.print(" label="); Serial.print(NAMES[cls]);
+    Serial.print(" prob=");  Serial.print(prob, 3);
+    Serial.print(" time=");  Serial.print(ms_f, 1); Serial.println(" ms");
+  }
+
+  // Libera l'output SOLO tramite hook ZANT (evita double-free)
+  if (zant_free_result) zant_free_result(out_raw);
+  out_raw = nullptr;
+
+  delay(5);
+}
+

--- a/examples/Nicla-SmartTrashCollector/README.md
+++ b/examples/Nicla-SmartTrashCollector/README.md
@@ -1,0 +1,23 @@
+# Nicla-SmartTrashCollector (Example)
+
+> Minimal 5-class waste sorting on **Nicla Vision** using **Z-Ant** runtime.
+> Pipeline: GC2145 camera (160×120 RGB565) → resize to 96×96 → NCHW float → `predict()` → top-1 → RGB LEDs and serial log.
+
+## Requirements
+- Arduino core: `arduino:mbed_nicla` (tested 4.4.1)
+- `arduino-cli`, `dfu-util` (only if using XIP flashing script)
+- Zig 0.14.x (only to build `libzant.a` via Z-Ant)
+- Z-Ant checked out (this repo)
+
+## Build the Z-Ant static library
+> We do **not** commit `libzant.a`. Build it and copy it under this example’s local library folder.
+
+```bash
+# From repo root
+zig build lib-gen  -Dmodel="YOUR_MODEL" -Dxip=true -Ddynamic -Ddo_export
+zig build lib-test -Dmodel="YOUR_MODEL" -Dxip=true -Ddynamic -Ddo_export
+zig build lib      -Dmodel="YOUR_MODEL" -Dtarget=thumb-freestanding -Dcpu=cortex_m7 -Dxip=true -Doptimize=ReleaseSmall
+
+# Copy the generated library:
+cp zig-out/YOUR_MODEL/libzant.a examples/Nicla-SmartTrashCollector/ZantLib/src/cortex-m7/
+

--- a/examples/Nicla-SmartTrashCollector/ZantLib/library.properties
+++ b/examples/Nicla-SmartTrashCollector/ZantLib/library.properties
@@ -1,0 +1,14 @@
+# library.properties (example)
+name=Zant
+version=1.0.0
+author=AnonymousZanter <AnonymousZanter@zant.com>
+maintainer=AnonymousZanter <AnonymousZanter@zant.com>
+sentence= Static Cortex-M7 library.
+paragraph= Library description
+category=Uncategorized
+url=https://zantfoundation.github.io/Website/
+architectures=mbed_nicla
+precompiled=full
+includes=lib_zant.h
+precompiled=true
+ldflags=-lzant

--- a/examples/Nicla-SmartTrashCollector/ZantLib/src/cortex-m7/README.md
+++ b/examples/Nicla-SmartTrashCollector/ZantLib/src/cortex-m7/README.md
@@ -1,0 +1,30 @@
+Put libzant.a here (not committed).
+
+# instruction for an easyer copy-paste
+
+#1
+zig build lib-gen  -Dmodel="mobilenet_v2"  -Dxip=true  -Ddynamic  -Ddo_export  -Denable_user_tests
+
+#2
+zig build lib-test  -Dmodel="mobilenet_v2"  -Dxip=true  -Ddynamic  -Ddo_export  -Denable_user_tests
+
+#3
+zig build lib  -Dmodel="mobilenet_v2" -Dtarget=thumb-freestanding  -Dcpu=cortex_m7  -Dxip=true -Doptimize=ReleaseSmall
+
+#4
+cp zig-out/mobilenet_v2/libzant.a ~/Arduino/libraries/ZantLib/src/cortex-m7
+
+#5
+cd examples/tiny_hack
+
+#6
+FQBN="arduino:mbed_nicla:nicla_vision"
+arduino-cli compile \
+ --fqbn "$FQBN" \
+ --export-binaries \
+ --libraries ~/Arduino/libraries \
+ --build-property "compiler.c.elf.extra_flags=-Wl,-T$PWD/custom.ld"
+
+#7
+./flash_nicla_xip.sh
+

--- a/examples/Nicla-SmartTrashCollector/ZantLib/src/lib_zant.h
+++ b/examples/Nicla-SmartTrashCollector/ZantLib/src/lib_zant.h
@@ -1,0 +1,72 @@
+#ifndef ZANT_ARDUINO_H
+#define ZANT_ARDUINO_H
+
+#include <Arduino.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ===================== PREDICT =====================
+typedef struct {
+    float* data;
+    size_t size;
+} zant_tensor_t;
+
+// Main prediction function (generated)
+int predict(
+    float*    input,        // e.g. [1,3,32,32] => 3072 floats
+    uint32_t* input_shape,  // e.g. {1,3,32,32}
+    uint32_t  shape_len,    // e.g. 4
+    float**   result        // out pointer to logits/probabilities
+);
+
+// ===================== WEIGHTS I/O LAYER =====================
+// Callback signature usata dal runtime per leggere "blocchi" di pesi
+typedef int (*zant_weight_read_callback_t)(size_t offset, uint8_t* buffer, size_t size);
+
+// Le seguenti API possono NON essere presenti in libzant.a se hai build XIP.
+// Le dichiariamo weak per consentire il link anche quando mancano.
+// Quando le usi a runtime verifica prima che il puntatore non sia NULL.
+
+// Inizializza il layer I/O (se presente)
+extern void zant_init_weights_io(void) __attribute__((weak));
+
+// Registra la callback di lettura pesi (se presente)
+extern void zant_register_weight_callback(zant_weight_read_callback_t cb) __attribute__((weak));
+
+// (Facoltativa) Fallback diretto: imposta base address dei pesi XIP (se supportata)
+extern void zant_set_weights_base_address(const uint8_t* base) __attribute__((weak));
+
+// (Facoltative) API info/debug — dichiara weak se il runtime le espone
+typedef struct {
+    bool            has_callback;
+    bool            has_base_address;
+    const uint8_t*  base_address;  // valido solo in direct mode
+    size_t          total_size;    // se disponibile
+} zant_weights_io_info_t;
+
+extern zant_weights_io_info_t zant_get_weights_io_info(void) __attribute__((weak));
+
+// ===================== ARDUINO HELPERS =====================
+// Queste le implementi nel tuo sketch o in uno .cpp di supporto
+void zant_arduino_init(void);
+int  zant_predict_image(uint8_t* rgb_image, int width, int height, float* output_probabilities);
+void zant_set_flash_weights_callback(void);
+
+// ===================== LOG CALLBACK =====================
+// Callback per debug logging
+typedef void (*zant_log_callback_t)(const char* message);
+extern void zant_set_log_callback(zant_log_callback_t callback) __attribute__((weak));
+
+// Alternative log function setter (per compatibilità con lib_face.zig)
+extern void setLogFunction(void (*func)(char*)) __attribute__((weak));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZANT_ARDUINO_H
+

--- a/examples/Nicla-SmartTrashCollector/compile_and_flash.sh
+++ b/examples/Nicla-SmartTrashCollector/compile_and_flash.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -f -- nicla_weights.bin nicla_internal.bin
+rm -rf -- build
+
+FQBN=arduino:mbed_nicla:nicla_vision
+SKETCH_DIR="${HOME}/Arduino/Nicla-SmartTrashCollector/"
+# keep this layout so your flash script still finds the ELF where it expects it
+BUILD_DIR="$SKETCH_DIR/build/arduino.mbed_nicla.nicla_vision"
+LD="$SKETCH_DIR/custom.ld"
+
+arduino-cli compile \
+    --fqbn "${FQBN}" \
+    --export-binaries \
+    --libraries ~/Arduino/libraries \
+    --build-property "compiler.c.elf.extra_flags=-Wl,-T$PWD/custom.ld"
+
+exec "$SKETCH_DIR/flash_nicla_xip.sh"
+

--- a/examples/Nicla-SmartTrashCollector/custom.ld
+++ b/examples/Nicla-SmartTrashCollector/custom.ld
@@ -1,0 +1,22 @@
+/* Place .flash_weights into external QSPI (XIP) */
+MEMORY
+{
+    QSPI (rx) : ORIGIN = 0x90000000, LENGTH = 16M
+}
+
+SECTIONS
+{
+    .flash_weights :
+    {
+    . = ALIGN(32);
+    __flash_weights_start__ = .;
+    KEEP(*(.flash_weights))
+    KEEP(*(.flash_weights.*))
+    KEEP(*(.rodata.flash_weights*))
+    . = ALIGN(32);
+    __flash_weights_end__ = .;
+    } > QSPI
+}
+
+PROVIDE(__flash_weights_size__ =
+ __flash_weights_end__ - __flash_weights_start__);

--- a/examples/Nicla-SmartTrashCollector/flash_nicla_xip.sh
+++ b/examples/Nicla-SmartTrashCollector/flash_nicla_xip.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# Configuration
+ARD="$HOME/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin"
+READELF="$ARD/arm-none-eabi-readelf"
+OBJCOPY="$ARD/arm-none-eabi-objcopy"
+ELF="./build/arduino.mbed_nicla.nicla_vision/Nicla-SmartTrashCollector.ino.elf"
+
+echo "=== Nicla Vision XIP Flashing Script ==="
+
+# Check if ELF exists
+if [ ! -f "$ELF" ]; then
+    echo "Error: ELF file not found at $ELF"
+    echo "Make sure you've compiled with Arduino CLI first"
+    exit 1
+fi
+
+# Check if tools exist
+if [ ! -f "$OBJCOPY" ]; then
+    echo "Error: objcopy not found at $OBJCOPY"
+    echo "Check your Arduino installation"
+    exit 1
+fi
+
+echo "1. Inspecting ELF sections..."
+"$READELF" -S "$ELF" | grep -E "\.flash_weights|\.text|Name" || true
+
+echo "2. Creating internal firmware binary (without weights)..."
+"$OBJCOPY" -O binary -R .flash_weights "$ELF" nicla_internal.bin
+
+echo "3. Creating weights binary..."
+"$OBJCOPY" -O binary -j .flash_weights "$ELF" nicla_weights.bin
+
+echo "4. File sizes:"
+ls -lh nicla_*.bin
+
+echo "5. Checking DFU devices..."
+dfu-util -l
+
+echo "6. Please put Nicla Vision in DFU mode (double-tap RESET)"
+read -p "Press Enter when ready..."
+
+echo "7. Flashing internal firmware..."
+dfu-util -a 0 -s 0x08040000:leave -D nicla_internal.bin
+
+echo "8. Put Nicla Vision in DFU mode again (double-tap RESET)"
+read -p "Press Enter when ready..."
+
+echo "9. Flashing weights to external flash..."
+dfu-util -a 1 -s 0x90000000:leave -D nicla_weights.bin
+
+echo "=== Flashing complete! ==="
+echo "Your device should now boot with XIP weights."

--- a/examples/Nicla-SmartTrashCollector/nicla_viewer.py
+++ b/examples/Nicla-SmartTrashCollector/nicla_viewer.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+nicla_viewer.py — Visualize Nicla 'FRME' grayscale frames over serial.
+
+Protocol (little-endian):
+  MAGIC: 'FRME' (4 bytes)
+  ver: uint8
+  seq: uint16
+  w:   uint16
+  h:   uint16
+  cls: uint8
+  prob_x1000: uint16
+  ms_x10:     uint16
+  payload_len: uint32   (should be w*h)
+  payload: gray bytes
+  crc32:   uint32       (Arduino-style of payload only)
+
+Keys:
+  q = quit
+  s = save PNG of current frame
+"""
+
+import argparse
+import sys
+import time
+import struct
+from pathlib import Path
+
+import numpy as np
+import serial
+import cv2
+
+MAGIC = b"FRME"
+HEADER_LEN = 20  # 4 (MAGIC) + 16 rest
+# Class names (adjust if you change your firmware table)
+CLASS_NAMES = ["general", "glass", "organic", "paper", "plastic"]
+
+def crc32_arduino(payload: bytes) -> int:
+    """Match the Arduino bitwise CRC (init 0xFFFFFFFF, poly 0xEDB88320, final ~)."""
+    crc = 0xFFFFFFFF
+    for byte in payload:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0xEDB88320
+            else:
+                crc >>= 1
+    return (~crc) & 0xFFFFFFFF
+
+def find_magic(buf: bytearray) -> int:
+    """Return index of MAGIC in buf or -1."""
+    return buf.find(MAGIC)
+
+def read_exact(ser: serial.Serial, n: int, timeout_s: float = 5.0) -> bytes:
+    """Read exactly n bytes or raise TimeoutError."""
+    out = bytearray()
+    t0 = time.time()
+    while len(out) < n:
+        chunk = ser.read(n - len(out))
+        if chunk:
+            out.extend(chunk)
+        else:
+            if (time.time() - t0) > timeout_s:
+                raise TimeoutError(f"Timed out reading {n} bytes (got {len(out)})")
+    return bytes(out)
+
+def parse_header(hdr: bytes):
+    assert len(hdr) == HEADER_LEN
+    if hdr[:4] != MAGIC:
+        raise ValueError("Bad MAGIC")
+    # <B H H H B H H I  (little-endian)
+    ver, seq, w, h, cls, prob_x1000, ms_x10, payload_len = struct.unpack_from(
+        "<B H H H B H H I", hdr, 4
+    )
+    return {
+        "ver": ver,
+        "seq": seq,
+        "w": w,
+        "h": h,
+        "cls": cls,
+        "prob": prob_x1000 / 1000.0,
+        "ms": ms_x10 / 10.0,
+        "payload_len": payload_len,
+    }
+
+def frame_generator(ser: serial.Serial):
+    """Yield parsed frames as dicts with keys: meta, img (H,W uint8)."""
+    buf = bytearray()
+    while True:
+        # Read whatever is available
+        chunk = ser.read(4096)
+        if chunk:
+            buf.extend(chunk)
+        else:
+            # small sleep prevents tight spin when no data
+            time.sleep(0.001)
+
+        # Try to find MAGIC
+        m = find_magic(buf)
+        if m < 0:
+            # keep buffer reasonable
+            if len(buf) > 1_000_000:
+                del buf[:-16]
+            continue
+
+        # Ensure we have full header
+        if len(buf) < m + HEADER_LEN:
+            continue  # wait for more
+
+        hdr = bytes(buf[m : m + HEADER_LEN])
+        try:
+            meta = parse_header(hdr)
+        except Exception:
+            # If header is corrupt, drop this MAGIC and continue
+            del buf[: m + 1]
+            continue
+
+        need = meta["payload_len"] + 4  # payload + CRC
+        total_needed = HEADER_LEN + need
+        if meta["payload_len"] > 10_000_000:  # sanity guard
+            # something's wrong, skip this MAGIC
+            del buf[: m + 4]
+            continue
+
+        # Wait for full frame
+        if len(buf) < m + total_needed:
+            continue
+
+        # Extract payload + crc
+        start = m + HEADER_LEN
+        payload = bytes(buf[start : start + meta["payload_len"]])
+        crc_rx = struct.unpack_from("<I", buf, start + meta["payload_len"])[0]
+        crc_calc = crc32_arduino(payload)
+
+        # Advance buffer
+        del buf[: m + total_needed]
+
+        if crc_rx != crc_calc:
+            print(
+                f"[warn] CRC mismatch (seq {meta['seq']}): rx=0x{crc_rx:08X}, calc=0x{crc_calc:08X}",
+                file=sys.stderr,
+            )
+            continue
+
+        # Convert payload into image
+        w, h = meta["w"], meta["h"]
+        if len(payload) != w * h:
+            print(
+                f"[warn] Bad payload size (seq {meta['seq']}): expected {w*h}, got {len(payload)}",
+                file=sys.stderr,
+            )
+            continue
+
+        img = np.frombuffer(payload, dtype=np.uint8).reshape((h, w))
+        yield {"meta": meta, "img": img}
+
+def draw_overlay(frame: np.ndarray, text_lines, scale=1.0):
+    y = 18
+    for line in text_lines:
+        cv2.putText(
+            frame,
+            line,
+            (8, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.45 * scale,
+            (255, 255, 255),
+            1,
+            cv2.LINE_AA,
+        )
+        y += int(18 * scale)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", required=True, help="Serial port (e.g., /dev/ttyACM0)")
+    ap.add_argument("--baud", type=int, default=921600, help="Baud rate")
+    ap.add_argument("--scale", type=int, default=4, help="Integer upscaling factor for display")
+    ap.add_argument("--save-dir", type=Path, default=Path("./captures"), help="Where to save PNGs on 's'")
+    ap.add_argument("--no-overlay", action="store_true", help="Disable overlay text")
+    args = ap.parse_args()
+
+    args.save_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        ser = serial.Serial(args.port, args.baud, timeout=0.01)
+    except Exception as e:
+        print(f"Failed to open {args.port}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Flush any pending text/noise
+    ser.reset_input_buffer()
+
+    win = "Nicla FRME Viewer"
+    cv2.namedWindow(win, cv2.WINDOW_NORMAL)
+
+    last_t = time.time()
+    fps = 0.0
+    n = 0
+
+    try:
+        for fr in frame_generator(ser):
+            meta = fr["meta"]
+            img = fr["img"]
+
+            # Upscale for readability
+            if args.scale > 1:
+                img_disp = cv2.resize(img, (img.shape[1]*args.scale, img.shape[0]*args.scale), interpolation=cv2.INTER_NEAREST)
+            else:
+                img_disp = img
+
+            img_disp = cv2.cvtColor(img_disp, cv2.COLOR_GRAY2BGR)
+
+            # FPS (simple EMA)
+            now = time.time()
+            dt = now - last_t
+            last_t = now
+            if dt > 0:
+                if n == 0:
+                    fps = 1.0 / dt
+                else:
+                    fps = 0.9 * fps + 0.1 * (1.0 / dt)
+            n += 1
+
+            # Overlay
+            if not args.no_overlay:
+                cls = meta["cls"]
+                name = CLASS_NAMES[cls] if 0 <= cls < len(CLASS_NAMES) else f"id{cls}"
+                lines = [
+                    f"seq: {meta['seq']}  ver: {meta['ver']}  fps: {fps:4.1f}",
+                    f"size: {meta['w']}x{meta['h']}",
+                    f"class: {cls} ({name})  prob: {meta['prob']:.3f}  time: {meta['ms']:.1f} ms",
+                ]
+                draw_overlay(img_disp, lines, scale=max(1, args.scale/2))
+
+            cv2.imshow(win, img_disp)
+            key = cv2.waitKey(1) & 0xFF
+            if key == ord('q'):
+                break
+            elif key == ord('s'):
+                # Save PNG with metadata in filename
+                out_path = args.save_dir / f"frame_seq{meta['seq']:05d}_cls{meta['cls']}_p{int(meta['prob']*1000):04d}.png"
+                cv2.imwrite(str(out_path), img)
+                print(f"Saved {out_path}")
+
+    except KeyboardInterrupt:
+        pass
+    except TimeoutError as e:
+        print(f"[error] {e}", file=sys.stderr)
+    finally:
+        try:
+            ser.close()
+        except Exception:
+            pass
+        cv2.destroyAllWindows()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
# Pull Request Template

## Description

Add a new example examples/Nicla-SmartTrashCollector for Arduino Nicla Vision demonstrating:

- XIP/QSPI memory-mapped weights with **Z-Ant**
- 5-class classification (Plastic/Paper/Glass/Organic/General)
- Discrete RGB LED feedback on Nicla (pins 23/24/25)
- Minimal scripts to **compile** with `arduino-cli` and **flash** via `dfu-util`
- Optional Python viewer/saver for grayscale/color frames

This provides an end-to-end reference from **ONNX** → **Z-Ant static lib** → **Arduino sketch** → **device**.

**Related Issue:** N/A

## Type of Change
- [x] New feature 🚀
- [x] Documentation update 📚

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests pass.

## Testing

**Environment**
- Board: Arduino Nicla Vision
- Core: arduino:mbed_nicla@4.4.1
- Tools: arduino-cli, dfu-util, zig 0.14.x (for building libzant.a), Python 3.10+ (optional viewer)

**Steps to reproduce**
1. Build Z-Ant static library for your model (example):
```bash
zig build lib \
  -Dmodel="<your_model_name>" \
  -Dtarget=thumb-freestanding -Dcpu=cortex_m7 \
  -Dxip=true -Doptimize=ReleaseSmall
# Output: zig-out/<your_model_name>/libzant.a
```

2. Copy the library into the Arduino shim:
```bash
mkdir -p ~/Arduino/libraries/ZantLib/src/cortex-m7
cp zig-out/<your_model_name>/libzant.a ~/Arduino/libraries/ZantLib/src/cortex-m7/
```

3. Copy the example to Arduino sketches:
```bash
cp -r examples/Nicla-SmartTrashCollector ~/Arduino/
```

4. From `~/Arduino/Nicla-SmartTrashCollector/`, compile & flash:
```bash
./compile_and_flash.sh
# When prompted, double-tap RESET for DFU to flash internal, then again for XIP weights.
```

5. Open serial monitor (e.g., `arduino-cli monitor -p /dev/ttyACM0 --config baudrate=921600`)
- Observe boot logs and classification prints.
- LED color changes according to predicted class.

6. (Optional) Use the provided Python script to visualize/save frames.


**Expected result**
- Internal firmware flashes, then XIP weights flash to external flash.
- On boot, QSPI XIP is configured and model runs.
- Serial shows prediction lines; LED shows class color.

## Additional Information
- `libzant.a` is not committed (binary) and is expected to be produced by Z-Ant for the user’s model; a minimal `ZantLib` header shim is included.
- Scripts assume the sketch folder name equals the `.ino` file name: `Nicla-SmartTrashCollector/Nicla-SmartTrashCollector.ino`.
- Example does not modify repo-wide files; all changes live under `examples/Nicla-SmartTrashCollector/`.