### PR TITLE
Complete refactoring conv_clip + dedicated test 

### DIFF
--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
@@ -78,12 +78,12 @@ pub const Fused_Conv_Clip = struct {
         // conv inputs X, W, (B if exists)
         const conv_inputs = try self.op_Conv.get_input_tensors();
         for (conv_inputs) |t| {
-            try inputs.append(t);
+            try inputs.append(allocator, t);
         }
 
         // clip parameters min, max (if exist)
-        if (self.op_Clip.min) |m| try inputs.append(m);
-        if (self.op_Clip.max) |M| try inputs.append(M);
+        if (self.op_Clip.min) |m| try inputs.append(allocator, m);
+        if (self.op_Clip.max) |M| try inputs.append(allocator, M);
 
         return inputs.toOwnedSlice(allocator);
     }

--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
@@ -28,113 +28,69 @@ const tensorMath = zant.core.tensor.math_standard;
 const utils = IR_zant.utils;
 
 /// Fused Conv+Clip operation for better performance
-/// This combines convolution followed by clipping (typically ReLU6: clip(x, 0, 6))
+/// This combines convolution followed by clipping
 /// Common pattern in MobileNet v2 and other efficient architectures
 pub const Fused_Conv_Clip = struct {
-    // Conv inputs
-    input_X: *TensorZant,
-    input_W: *TensorZant,
-    input_B: ?*TensorZant,
+    op_name: []const u8,
+    op_Conv: operators.Conv,
+    op_Clip: operators.Clip,
 
-    // Clip parameters
-    min: ?*TensorZant,
-    max: ?*TensorZant,
+    //DONE
+    pub fn init_fused_op(fusion_list: std.ArrayList(*NodeZant)) !Fused_Conv_Clip {
+        //ensure correct operations are given
+        if (fusion_list.items.len != 2) return error.WrongNumberOfElements;
+        if (fusion_list.items[0].op != .conv) return error.WrongOpAtPose0;
+        if (fusion_list.items[1].op != .clip) return error.WrongOpAtPose2;
 
-    // Output
-    output_Y: *TensorZant,
+        // Extract the specific operations from the unionsnono
+        const conv_op = switch (fusion_list.items[0].op) {
+            .conv => |c| c,
+            else => return error.InvalidConvOperation,
+        };
 
-    // Conv attributes
-    auto_pad: []const u8,
-    dilations: ?[]i64,
-    group: i64,
-    kernel_shape: ?[]i64,
-    pads: ?[]i64,
-    strides: ?[]i64,
+        const clip_op = switch (fusion_list.items[1].op) {
+            .clip => |cl| cl,
+            else => return error.InvalidClipOperation,
+        };
 
-    pub fn init_from_conv_clip(conv_node: NodeProto, clip_node: NodeProto) !Fused_Conv_Clip {
-        // Get Conv inputs
-        const input_X = if (tensorZant_lib.tensorMap.getPtr(conv_node.input[0])) |ptr| ptr else return error.input_X_notFound;
-        const input_W = if (tensorZant_lib.tensorMap.getPtr(conv_node.input[1])) |ptr| ptr else return error.input_W_notFound;
-        const input_B = if (conv_node.input.len > 2) if (tensorZant_lib.tensorMap.getPtr(conv_node.input[2])) |ptr| ptr else return error.input_B_notFound else null;
-
-        // Get Clip parameters
-        const min = if (clip_node.input.len > 1) tensorZant_lib.tensorMap.getPtr(clip_node.input[1]) else null;
-        const max = if (clip_node.input.len > 2) tensorZant_lib.tensorMap.getPtr(clip_node.input[2]) else null;
-
-        // Output is the clip output
-        const output_Y = if (tensorZant_lib.tensorMap.getPtr(clip_node.output[0])) |ptr| ptr else return error.output_Y_notFound;
-
-        // Parse Conv attributes
-        var auto_pad: []const u8 = "NOTSET";
-        var dilations: ?[]i64 = null;
-        var group: i64 = 1;
-        var kernel_shape: ?[]i64 = null;
-        var pads: ?[]i64 = null;
-        var strides: ?[]i64 = null;
-
-        for (conv_node.attribute) |attr| {
-            if (std.mem.eql(u8, attr.name, "auto_pad")) {
-                if (attr.type == onnx.AttributeType.STRING) auto_pad = attr.s;
-            }
-            if (std.mem.eql(u8, attr.name, "dilations")) {
-                if (attr.type == onnx.AttributeType.INTS) dilations = attr.ints;
-            }
-            if (std.mem.eql(u8, attr.name, "group")) {
-                if (attr.type == onnx.AttributeType.INT) group = attr.i;
-            }
-            if (std.mem.eql(u8, attr.name, "kernel_shape")) {
-                if (attr.type == onnx.AttributeType.INTS) kernel_shape = attr.ints;
-            }
-            if (std.mem.eql(u8, attr.name, "pads")) {
-                if (attr.type == onnx.AttributeType.INTS) pads = attr.ints;
-            }
-            if (std.mem.eql(u8, attr.name, "strides")) {
-                if (attr.type == onnx.AttributeType.INTS) strides = attr.ints;
-            }
-        }
-
-        // Set output type
-        if (output_Y.ty == tensorZant_lib.TensorType.undefined) output_Y.ty = input_X.ty;
+        // Downgrade LINK tensors between fudes noted to FUSED_LINK tensors
+        conv_op.output_Y.set_tensorCategory(TensorCategory.FUSED_LINK);
 
         return Fused_Conv_Clip{
-            .input_X = input_X,
-            .input_W = input_W,
-            .input_B = input_B,
-            .min = min,
-            .max = max,
-            .output_Y = output_Y,
-            .auto_pad = auto_pad,
-            .dilations = dilations,
-            .group = group,
-            .kernel_shape = kernel_shape,
-            .pads = pads,
-            .strides = strides,
+            .op_name = try NodeZant_lib.getFusedOpsName(fusion_list),
+            .op_Conv = conv_op,
+            .op_Clip = clip_op,
         };
     }
 
+    //DONE
+    //TODO  check  again
     pub fn get_output_shape(self: Fused_Conv_Clip) []usize {
-        return self.output_Y.getShape();
+        return self.op_Clip.get_output_shape();
     }
 
+    //DONE
+    //TODO controlla allocazioni e defer
     pub fn get_input_tensors(self: Fused_Conv_Clip) ![]*TensorZant {
         var inputs: std.ArrayList(*TensorZant) = .empty;
         defer inputs.deinit(allocator);
 
-        try inputs.append(allocator, self.input_X);
-        try inputs.append(allocator, self.input_W);
-        if (self.input_B) |bias| try inputs.append(allocator, bias);
-        if (self.min) |min_tensor| try inputs.append(allocator, min_tensor);
-        if (self.max) |max_tensor| try inputs.append(allocator, max_tensor);
+        // conv inputs X, W, (B if exists)
+        const conv_inputs = try self.op_Conv.get_input_tensors();
+        for (conv_inputs) |t| {
+            try inputs.append(t);
+        }
+
+        // clip parameters min, max (if exist)
+        if (self.op_Clip.min) |m| try inputs.append(m);
+        if (self.op_Clip.max) |M| try inputs.append(M);
 
         return inputs.toOwnedSlice(allocator);
     }
 
+    //DONE
     pub fn get_output_tensors(self: Fused_Conv_Clip) ![]*TensorZant {
-        var outputs: std.ArrayList(*TensorZant) = .empty;
-        defer outputs.deinit(allocator);
-
-        try outputs.append(allocator, self.output_Y);
-        return outputs.toOwnedSlice(allocator);
+        return self.op_Clip.get_output_tensors();
     }
 
     pub fn write_op(self: Fused_Conv_Clip, writer: *std.Io.Writer) !void {
@@ -142,31 +98,31 @@ pub const Fused_Conv_Clip = struct {
         var tensor_X_string: []u8 = undefined;
         defer allocator.free(tensor_X_string);
 
-        if (self.input_X.tc == TensorCategory.INITIALIZER) {
+        if (self.op_Conv.input_X.tc == TensorCategory.INITIALIZER) {
             tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try utils.getSanitizedName(self.input_X.name),
+                try utils.getSanitizedName(self.op_Conv.input_X.name),
                 ")",
             });
         } else {
-            tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.input_X.name), ")" });
+            tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.op_Conv.input_X.name), ")" });
         }
 
         var tensor_W_string: []u8 = undefined;
         defer allocator.free(tensor_W_string);
-        if (self.input_W.tc == TensorCategory.INITIALIZER) {
+        if (self.op_Conv.input_W.tc == TensorCategory.INITIALIZER) {
             tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try utils.getSanitizedName(self.input_W.name),
+                try utils.getSanitizedName(self.op_Conv.input_W.name),
                 ")",
             });
         } else {
-            tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.input_W.name), ")" });
+            tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.op_Conv.input_W.name), ")" });
         }
 
         var bias_string: []u8 = undefined;
         defer allocator.free(bias_string);
-        if (self.input_B) |input_B| {
+        if (self.op_Conv.input_B) |input_B| {
             const B_name = try utils.getSanitizedName(input_B.name);
             bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&param_lib.tensor_", B_name, ")" });
         } else {
@@ -174,14 +130,14 @@ pub const Fused_Conv_Clip = struct {
         }
 
         // Build stride string
-        if (self.strides == null) return error.StrideNotFound;
-        const stride_string: []const u8 = try utils.i64SliceToUsizeArrayString(self.strides.?);
+        if (self.op_Conv.strides == null) return error.StrideNotFound;
+        const stride_string: []const u8 = try utils.i64SliceToUsizeArrayString(self.op_Conv.strides.?);
 
         // Build pads string
         var pads_string: []const u8 = "null";
-        if (self.pads != null) {
-            if (self.pads.?.len > 0) {
-                pads_string = try utils.i64SliceToUsizeArrayString(self.pads.?);
+        if (self.op_Conv.pads != null) {
+            if (self.op_Conv.pads.?.len > 0) {
+                pads_string = try utils.i64SliceToUsizeArrayString(self.op_Conv.pads.?);
             } else {
                 pads_string = "&[_]usize{}";
             }
@@ -189,9 +145,9 @@ pub const Fused_Conv_Clip = struct {
 
         // Build dilations string
         var dilat_string: []const u8 = "null";
-        if (self.dilations != null) {
-            if (self.dilations.?.len > 0) {
-                dilat_string = try utils.i64SliceToUsizeArrayString(self.dilations.?);
+        if (self.op_Conv.dilations != null) {
+            if (self.op_Conv.dilations.?.len > 0) {
+                dilat_string = try utils.i64SliceToUsizeArrayString(self.op_Conv.dilations.?);
             } else {
                 dilat_string = "&[_]usize{1} ** 2";
             }
@@ -201,7 +157,7 @@ pub const Fused_Conv_Clip = struct {
         var min_string: []const u8 = "null";
         var max_string: []const u8 = "null";
 
-        if (self.min) |min_tensor| {
+        if (self.op_Clip.min) |min_tensor| {
             if (min_tensor.tc == TensorCategory.INITIALIZER) {
                 min_string = try std.fmt.allocPrint(allocator, "@constCast(&param_lib.tensor_{s})", .{try utils.getSanitizedName(min_tensor.name)});
             } else {
@@ -210,7 +166,7 @@ pub const Fused_Conv_Clip = struct {
         }
         defer if (!std.mem.eql(u8, min_string, "null")) allocator.free(@constCast(min_string));
 
-        if (self.max) |max_tensor| {
+        if (self.op_Clip.max) |max_tensor| {
             if (max_tensor.tc == TensorCategory.INITIALIZER) {
                 max_string = try std.fmt.allocPrint(allocator, "@constCast(&param_lib.tensor_{s})", .{try utils.getSanitizedName(max_tensor.name)});
             } else {
@@ -220,9 +176,9 @@ pub const Fused_Conv_Clip = struct {
         defer if (!std.mem.eql(u8, max_string, "null")) allocator.free(@constCast(max_string));
 
         // Handle mixed precision (similar to op_conv.zig)
-        const target_type = self.output_Y.ty.toString();
-        const need_kernel_cast = !std.mem.eql(u8, self.input_W.ty.toString(), target_type);
-        const need_bias_cast = if (self.input_B) |bias| !std.mem.eql(u8, bias.ty.toString(), target_type) else false;
+        const target_type = self.op_Clip.output.ty.toString();
+        const need_kernel_cast = !std.mem.eql(u8, self.op_Conv.input_W.ty.toString(), target_type);
+        const need_bias_cast = if (self.op_Conv.input_B) |bias| !std.mem.eql(u8, bias.ty.toString(), target_type) else false;
 
         var final_kernel_string: []const u8 = tensor_W_string;
         var final_bias_string: []const u8 = bias_string;
@@ -231,10 +187,10 @@ pub const Fused_Conv_Clip = struct {
         defer if (need_free_kernel) allocator.free(@constCast(final_kernel_string));
         defer if (need_free_bias) allocator.free(@constCast(final_bias_string));
 
-        const output_name_sanitized = try utils.getSanitizedName(self.output_Y.name);
+        const output_name_sanitized = try utils.getSanitizedName(self.op_Clip.output.name);
 
         if (need_kernel_cast) {
-            final_kernel_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_W_casted_{s}", .{ try utils.getSanitizedName(self.input_W.name), output_name_sanitized });
+            final_kernel_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_W_casted_{s}", .{ try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized });
             need_free_kernel = true;
 
             _ = try writer.print(
@@ -242,14 +198,14 @@ pub const Fused_Conv_Clip = struct {
                 \\    tensMath.cast_lean({s}, &tensor_{s}, &tensor_{s}_W_casted_{s}) catch return -1;
                 \\
             , .{
-                try utils.getSanitizedName(self.input_W.name), output_name_sanitized,      target_type,
-                try utils.getSanitizedName(self.input_W.name), self.input_W.ty.toString(), try utils.getSanitizedName(self.input_W.name),
-                try utils.getSanitizedName(self.input_W.name), output_name_sanitized,
+                try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized,              target_type,
+                try utils.getSanitizedName(self.op_Conv.input_W.name), self.op_Conv.input_W.ty.toString(), try utils.getSanitizedName(self.op_Conv.input_W.name),
+                try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized,
             });
         }
 
-        if (need_bias_cast and self.input_B != null) {
-            final_bias_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_B_casted_{s}", .{ try utils.getSanitizedName(self.input_B.?.name), output_name_sanitized });
+        if (need_bias_cast and self.op_Conv.input_B != null) {
+            final_bias_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_B_casted_{s}", .{ try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized });
             need_free_bias = true;
 
             _ = try writer.print(
@@ -257,9 +213,9 @@ pub const Fused_Conv_Clip = struct {
                 \\    tensMath.cast_lean({s}, &tensor_{s}, &tensor_{s}_B_casted_{s}) catch return -1;
                 \\
             , .{
-                try utils.getSanitizedName(self.input_B.?.name), output_name_sanitized,        target_type,
-                try utils.getSanitizedName(self.input_B.?.name), self.input_B.?.ty.toString(), try utils.getSanitizedName(self.input_B.?.name),
-                try utils.getSanitizedName(self.input_B.?.name), output_name_sanitized,
+                try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized,                target_type,
+                try utils.getSanitizedName(self.op_Conv.input_B.?.name), self.op_Conv.input_B.?.ty.toString(), try utils.getSanitizedName(self.op_Conv.input_B.?.name),
+                try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized,
             });
         }
 
@@ -291,67 +247,37 @@ pub const Fused_Conv_Clip = struct {
             stride_string, //Strides
             pads_string, //Pads
             dilat_string, //Dilations
-            self.group, //Group
-            self.auto_pad, //auto_pad
+            self.op_Conv.group, //Group
+            self.op_Conv.auto_pad, //auto_pad
             min_string, //min
             max_string, //max
         });
     }
 
+    //DONE
     pub fn compute_output_shape(self: Fused_Conv_Clip) []usize {
-        var output_shape: []usize = undefined;
-        const input_shape = self.input_X.get_shape();
-        const kernel_shape = self.input_W.get_shape();
-        const stride = self.strides;
-        const pads = self.pads;
-        const dilations = self.dilations;
-        const auto_pad = self.auto_pad;
-        output_shape = try tensorMath.get_convolution_output_shape(
-            input_shape,
-            kernel_shape,
-            try utils.i64SliceToUsizeSlice(stride.?),
-            if (pads != null) try utils.i64SliceToUsizeSlice(pads.?) else null,
-            try utils.i64SliceToUsizeSlice(dilations.?),
-            auto_pad,
-        );
-        self.output_Y.shape = output_shape;
-        return output_shape;
+        return self.op_Clip.compute_output_shape();
     }
 
+    //DONE
     pub fn print(self: Fused_Conv_Clip) void {
-        std.debug.print("\n CONV+CLIP FUSED:\n {any}", .{self});
+        std.debug.print("\n Fused_Conv_Clip:\n {any}", .{self});
     }
 
+    //DONE
+    //if there are problems check the conv.sobtitute_tensors, it changes also the output that here is not considered
     pub fn sobstitute_tensors(self: *Fused_Conv_Clip, old_tensor: *TensorZant, new_tensor: *TensorZant) !void {
-        if (self.input_X == old_tensor) {
-            self.input_X = new_tensor;
-            return;
-        }
-        if (self.input_W == old_tensor) {
-            self.input_W = new_tensor;
-            return;
-        }
-        if (self.input_B != null and self.input_B.? == old_tensor) {
-            self.input_B = new_tensor;
-            return;
-        }
-        if (self.min != null and self.min.? == old_tensor) {
-            self.min = new_tensor;
-            return;
-        }
-        if (self.max != null and self.max.? == old_tensor) {
-            self.max = new_tensor;
-            return;
-        }
-        if (self.output_Y == old_tensor) {
-            self.output_Y = new_tensor;
-            return;
-        }
-        return error.TensorNotFound;
+        //Try to substitute Conv tensor
+        self.op_Conv.sobstitute_tensors(old_tensor, new_tensor) catch {
+            //If not found in Conv, try among Clip tensors
+            self.op_Clip.sobstitute_tensors(old_tensor, new_tensor) catch {
+                return error.OldTensorNotFoundInSubstitution;
+            };
+        };
     }
 
     // --- Fusion --
-    /// Pattern detection function for DequantizeLinear -> Pad -> QuantizeLinear -> QLinearConv
+    /// Pattern detection function for Conv -> Clip
     pub fn fn_pattern_detection(graph: *GraphZant, root_node: *NodeZant) anyerror!?std.ArrayList(*NodeZant) {
         _ = graph; // Not used in this sequential pattern
 
@@ -404,12 +330,7 @@ pub const Fused_Conv_Clip = struct {
         return NodeZant{
             .name = try NodeZant_lib.getFusedOpsName(node_list),
             .op_type = try NodeZant_lib.getFusedOpsType(node_list),
-            .op = Op_union{
-                .fused_Conv_Clip = try init_from_conv_clip(
-                    node_list.items[0].nodeProto.?.*, //Conv proto node
-                    node_list.items[1].nodeProto.?.*, //Clip proto node
-                ),
-            },
+            .op = Op_union{ .fused_Conv_Clip = try init_fused_op(node_list) },
             .next = cloned_next,
             .nodeProto = null,
             .ready = false,
@@ -451,3 +372,459 @@ pub const Fused_Conv_Clip = struct {
         try graph.nodes.append(allocator, fused_node);
     }
 };
+
+// ---OLD VERSION BELOW IF NEEDED---
+
+// const std = @import("std");
+// const zant = @import("zant");
+// const allocator = zant.utils.allocator.allocator;
+// const IR_zant = @import("../../IR_zant.zig");
+
+// // --- onnx ---
+// const onnx = zant.onnx;
+// const ModelProto = onnx.ModelProto;
+// const GraphProto = onnx.GraphProto;
+// const NodeProto = onnx.NodeProto;
+// const TensorProto = onnx.TensorProto;
+
+// // --- zant IR---
+// const tensorZant_lib = IR_zant.tensorZant_lib;
+// const TensorZant = tensorZant_lib.TensorZant;
+// const TensorCategory = tensorZant_lib.TensorCategory;
+// const NodeZant_lib = IR_zant.NodeZant_lib;
+// const NodeZant = NodeZant_lib.NodeZant;
+// const GraphZant = IR_zant.GraphZant;
+// const IR_utils = IR_zant.utils;
+
+// // --- union ---
+// const Op_union = @import("../op_union.zig").Op_union;
+// const operators = IR_zant.operators;
+
+// const tensorMath = zant.core.tensor.math_standard;
+
+// const utils = IR_zant.utils;
+
+// /// Fused Conv+Clip operation for better performance
+// /// This combines convolution followed by clipping (typically ReLU6: clip(x, 0, 6))
+// /// Common pattern in MobileNet v2 and other efficient architectures
+// pub const Fused_Conv_Clip = struct {
+//     // Conv inputs
+//     input_X: *TensorZant,
+//     input_W: *TensorZant,
+//     input_B: ?*TensorZant,
+
+//     // Clip parameters
+//     min: ?*TensorZant,
+//     max: ?*TensorZant,
+
+//     // Output
+//     output_Y: *TensorZant,
+
+//     // Conv attributes
+//     auto_pad: []const u8,
+//     dilations: ?[]i64,
+//     group: i64,
+//     kernel_shape: ?[]i64,
+//     pads: ?[]i64,
+//     strides: ?[]i64,
+
+//     pub fn init_from_conv_clip(conv_node: NodeProto, clip_node: NodeProto) !Fused_Conv_Clip {
+//         // Get Conv inputs
+//         const input_X = if (tensorZant_lib.tensorMap.getPtr(conv_node.input[0])) |ptr| ptr else return error.input_X_notFound;
+//         const input_W = if (tensorZant_lib.tensorMap.getPtr(conv_node.input[1])) |ptr| ptr else return error.input_W_notFound;
+//         const input_B = if (conv_node.input.len > 2) if (tensorZant_lib.tensorMap.getPtr(conv_node.input[2])) |ptr| ptr else return error.input_B_notFound else null;
+
+//         // Get Clip parameters
+//         const min = if (clip_node.input.len > 1) tensorZant_lib.tensorMap.getPtr(clip_node.input[1]) else null;
+//         const max = if (clip_node.input.len > 2) tensorZant_lib.tensorMap.getPtr(clip_node.input[2]) else null;
+
+//         // Output is the clip output
+//         const output_Y = if (tensorZant_lib.tensorMap.getPtr(clip_node.output[0])) |ptr| ptr else return error.output_Y_notFound;
+
+//         // Parse Conv attributes
+//         var auto_pad: []const u8 = "NOTSET";
+//         var dilations: ?[]i64 = null;
+//         var group: i64 = 1;
+//         var kernel_shape: ?[]i64 = null;
+//         var pads: ?[]i64 = null;
+//         var strides: ?[]i64 = null;
+
+//         for (conv_node.attribute) |attr| {
+//             if (std.mem.eql(u8, attr.name, "auto_pad")) {
+//                 if (attr.type == onnx.AttributeType.STRING) auto_pad = attr.s;
+//             }
+//             if (std.mem.eql(u8, attr.name, "dilations")) {
+//                 if (attr.type == onnx.AttributeType.INTS) dilations = attr.ints;
+//             }
+//             if (std.mem.eql(u8, attr.name, "group")) {
+//                 if (attr.type == onnx.AttributeType.INT) group = attr.i;
+//             }
+//             if (std.mem.eql(u8, attr.name, "kernel_shape")) {
+//                 if (attr.type == onnx.AttributeType.INTS) kernel_shape = attr.ints;
+//             }
+//             if (std.mem.eql(u8, attr.name, "pads")) {
+//                 if (attr.type == onnx.AttributeType.INTS) pads = attr.ints;
+//             }
+//             if (std.mem.eql(u8, attr.name, "strides")) {
+//                 if (attr.type == onnx.AttributeType.INTS) strides = attr.ints;
+//             }
+//         }
+
+//         // Set output type
+//         if (output_Y.ty == tensorZant_lib.TensorType.undefined) output_Y.ty = input_X.ty;
+
+//         return Fused_Conv_Clip{
+//             .input_X = input_X,
+//             .input_W = input_W,
+//             .input_B = input_B,
+//             .min = min,
+//             .max = max,
+//             .output_Y = output_Y,
+//             .auto_pad = auto_pad,
+//             .dilations = dilations,
+//             .group = group,
+//             .kernel_shape = kernel_shape,
+//             .pads = pads,
+//             .strides = strides,
+//         };
+//     }
+
+//     pub fn get_output_shape(self: Fused_Conv_Clip) []usize {
+//         return self.output_Y.getShape();
+//     }
+
+//     pub fn get_input_tensors(self: Fused_Conv_Clip) ![]*TensorZant {
+//         var inputs: std.ArrayList(*TensorZant) = .empty;
+//         defer inputs.deinit(allocator);
+
+//         try inputs.append(allocator, self.input_X);
+//         try inputs.append(allocator, self.input_W);
+//         if (self.input_B) |bias| try inputs.append(allocator, bias);
+//         if (self.min) |min_tensor| try inputs.append(allocator, min_tensor);
+//         if (self.max) |max_tensor| try inputs.append(allocator, max_tensor);
+
+//         return inputs.toOwnedSlice(allocator);
+//     }
+
+//     pub fn get_output_tensors(self: Fused_Conv_Clip) ![]*TensorZant {
+//         var outputs: std.ArrayList(*TensorZant) = .empty;
+//         defer outputs.deinit(allocator);
+
+//         try outputs.append(allocator, self.output_Y);
+//         return outputs.toOwnedSlice(allocator);
+//     }
+
+//     pub fn write_op(self: Fused_Conv_Clip, writer: *std.Io.Writer) !void {
+//         // Build Conv operation strings (similar to op_conv.zig)
+//         var tensor_X_string: []u8 = undefined;
+//         defer allocator.free(tensor_X_string);
+
+//         if (self.input_X.tc == TensorCategory.INITIALIZER) {
+//             tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{
+//                 "@constCast(&param_lib.tensor_",
+//                 try utils.getSanitizedName(self.input_X.name),
+//                 ")",
+//             });
+//         } else {
+//             tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.input_X.name), ")" });
+//         }
+
+//         var tensor_W_string: []u8 = undefined;
+//         defer allocator.free(tensor_W_string);
+//         if (self.input_W.tc == TensorCategory.INITIALIZER) {
+//             tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{
+//                 "@constCast(&param_lib.tensor_",
+//                 try utils.getSanitizedName(self.input_W.name),
+//                 ")",
+//             });
+//         } else {
+//             tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.input_W.name), ")" });
+//         }
+
+//         var bias_string: []u8 = undefined;
+//         defer allocator.free(bias_string);
+//         if (self.input_B) |input_B| {
+//             const B_name = try utils.getSanitizedName(input_B.name);
+//             bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&param_lib.tensor_", B_name, ")" });
+//         } else {
+//             bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{"null"});
+//         }
+
+//         // Build stride string
+//         if (self.strides == null) return error.StrideNotFound;
+//         const stride_string: []const u8 = try utils.i64SliceToUsizeArrayString(self.strides.?);
+
+//         // Build pads string
+//         var pads_string: []const u8 = "null";
+//         if (self.pads != null) {
+//             if (self.pads.?.len > 0) {
+//                 pads_string = try utils.i64SliceToUsizeArrayString(self.pads.?);
+//             } else {
+//                 pads_string = "&[_]usize{}";
+//             }
+//         }
+
+//         // Build dilations string
+//         var dilat_string: []const u8 = "null";
+//         if (self.dilations != null) {
+//             if (self.dilations.?.len > 0) {
+//                 dilat_string = try utils.i64SliceToUsizeArrayString(self.dilations.?);
+//             } else {
+//                 dilat_string = "&[_]usize{1} ** 2";
+//             }
+//         }
+
+//         // Build clip bounds strings
+//         var min_string: []const u8 = "null";
+//         var max_string: []const u8 = "null";
+
+//         if (self.min) |min_tensor| {
+//             if (min_tensor.tc == TensorCategory.INITIALIZER) {
+//                 min_string = try std.fmt.allocPrint(allocator, "@constCast(&param_lib.tensor_{s})", .{try utils.getSanitizedName(min_tensor.name)});
+//             } else {
+//                 min_string = try std.fmt.allocPrint(allocator, "&tensor_{s}", .{try utils.getSanitizedName(min_tensor.name)});
+//             }
+//         }
+//         defer if (!std.mem.eql(u8, min_string, "null")) allocator.free(@constCast(min_string));
+
+//        if (self.op_Clip.max) |max_tensor| {
+//            if (max_tensor.tc == TensorCategory.INITIALIZER) {
+//                 max_string = try std.fmt.allocPrint(allocator, "@constCast(&param_lib.tensor_{s})", .{try utils.getSanitizedName(max_tensor.name)});
+//             } else {
+//                 max_string = try std.fmt.allocPrint(allocator, "&tensor_{s}", .{try utils.getSanitizedName(max_tensor.name)});
+//             }
+//         }
+//         defer if (!std.mem.eql(u8, max_string, "null")) allocator.free(@constCast(max_string));
+
+//         // Handle mixed precision (similar to op_conv.zig)
+//         const target_type = self.op_Clip.output.ty.toString();
+//         const need_kernel_cast = !std.mem.eql(u8, self.op_Conv.input_W.ty.toString(), target_type);
+//         const need_bias_cast = if (self.op_Conv.input_B) |bias| !std.mem.eql(u8, bias.ty.toString(), target_type) else false;
+
+//         var final_kernel_string: []const u8 = tensor_W_string;
+//         var final_bias_string: []const u8 = bias_string;
+//         var need_free_kernel = false;
+//         var need_free_bias = false;
+//         defer if (need_free_kernel) allocator.free(@constCast(final_kernel_string));
+//         defer if (need_free_bias) allocator.free(@constCast(final_bias_string));
+
+//         const output_name_sanitized = try utils.getSanitizedName(self.op_Clip.output.name);
+
+//         if (need_kernel_cast) {
+//             final_kernel_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_W_casted_{s}", .{ try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized });
+//             need_free_kernel = true;
+
+//             _ = try writer.print(
+//                 \\    var tensor_{s}_W_casted_{s} = Tensor({s}).fromShape(&allocator, &tensor_{s}.shape) catch return -2;
+//                 \\    tensMath.cast_lean({s}, &tensor_{s}, &tensor_{s}_W_casted_{s}) catch return -1;
+//                 \\
+//             , .{
+//                 try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized,              target_type,
+//                 try utils.getSanitizedName(self.op_Conv.input_W.name), self.op_Conv.input_W.ty.toString(), try utils.getSanitizedName(self.op_Conv.input_W.name),
+//                 try utils.getSanitizedName(self.op_Conv.input_W.name), output_name_sanitized,
+//             });
+//         }
+
+//         if (need_bias_cast and self.op_Conv.input_B != null) {
+//             final_bias_string = try std.fmt.allocPrint(allocator, "&tensor_{s}_B_casted_{s}", .{ try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized });
+//             need_free_bias = true;
+
+//             _ = try writer.print(
+//                 \\    var tensor_{s}_B_casted_{s} = Tensor({s}).fromShape(&allocator, &tensor_{s}.shape) catch return -2;
+//                 \\    tensMath.cast_lean({s}, &tensor_{s}, &tensor_{s}_B_casted_{s}) catch return -1;
+//                 \\
+//             , .{
+//                 try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized,                target_type,
+//                 try utils.getSanitizedName(self.op_Conv.input_B.?.name), self.op_Conv.input_B.?.ty.toString(), try utils.getSanitizedName(self.op_Conv.input_B.?.name),
+//                 try utils.getSanitizedName(self.op_Conv.input_B.?.name), output_name_sanitized,
+//             });
+//         }
+
+//         // Generate the fused conv+clip call
+//         _ = try writer.print(
+//             \\
+//             \\    @setEvalBranchQuota(10000);
+//             \\    // Fused Conv+Clip operation for better performance
+//             \\    tensMath.conv_clip_lean(
+//             \\        {s}, //type
+//             \\        {s}, //input
+//             \\        {s}, //kernel
+//             \\        &tensor_{s}, //output
+//             \\        {s}, //bias
+//             \\        {s}, //stride
+//             \\        {s}, //pads
+//             \\        {s}, //dilations
+//             \\        {}, //group
+//             \\        "{s}", //auto_pad
+//             \\        {s}, //min
+//             \\        {s}, //max
+//             \\    ) catch return -1;
+//         , .{
+//             target_type,
+//             tensor_X_string, //Input
+//             final_kernel_string, //Kernel (possibly casted)
+//             output_name_sanitized, //Output
+//             final_bias_string, //Bias (possibly casted)
+//             stride_string, //Strides
+//             pads_string, //Pads
+//             dilat_string, //Dilations
+//             self.op_Conv.group, //Group
+//             self.op_Conv.auto_pad, //auto_pad
+//             min_string, //min
+//             max_string, //max
+//         });
+//     }
+
+//     pub fn compute_output_shape(self: Fused_Conv_Clip) []usize {
+//         var output_shape: []usize = undefined;
+//         const input_shape = self.input_X.get_shape();
+//         const kernel_shape = self.input_W.get_shape();
+//         const stride = self.strides;
+//         const pads = self.pads;
+//         const dilations = self.dilations;
+//         const auto_pad = self.auto_pad;
+//         output_shape = try tensorMath.get_convolution_output_shape(
+//             input_shape,
+//             kernel_shape,
+//             try utils.i64SliceToUsizeSlice(stride.?),
+//             if (pads != null) try utils.i64SliceToUsizeSlice(pads.?) else null,
+//             try utils.i64SliceToUsizeSlice(dilations.?),
+//             auto_pad,
+//         );
+//         self.output_Y.shape = output_shape;
+//         return output_shape;
+//     }
+
+//     pub fn print(self: Fused_Conv_Clip) void {
+//         std.debug.print("\n CONV+CLIP FUSED:\n {any}", .{self});
+//     }
+
+//     pub fn sobstitute_tensors(self: *Fused_Conv_Clip, old_tensor: *TensorZant, new_tensor: *TensorZant) !void {
+//         if (self.input_X == old_tensor) {
+//             self.input_X = new_tensor;
+//             return;
+//         }
+//         if (self.input_W == old_tensor) {
+//             self.input_W = new_tensor;
+//             return;
+//         }
+//         if (self.input_B != null and self.input_B.? == old_tensor) {
+//             self.input_B = new_tensor;
+//             return;
+//         }
+//         if (self.min != null and self.min.? == old_tensor) {
+//             self.min = new_tensor;
+//             return;
+//         }
+//         if (self.max != null and self.max.? == old_tensor) {
+//             self.max = new_tensor;
+//             return;
+//         }
+//         if (self.output_Y == old_tensor) {
+//             self.output_Y = new_tensor;
+//             return;
+//         }
+//         return error.TensorNotFound;
+//     }
+
+//     // --- Fusion --
+//     /// Pattern detection function for DequantizeLinear -> Pad -> QuantizeLinear -> QLinearConv
+//     pub fn fn_pattern_detection(graph: *GraphZant, root_node: *NodeZant) anyerror!?std.ArrayList(*NodeZant) {
+//         _ = graph; // Not used in this sequential pattern
+
+//         // Only start detection from DequantizeLinear nodes
+//         if (root_node.op != .conv) {
+//             return null;
+//         }
+
+//         var node_list: std.ArrayList(*NodeZant) = .empty;
+//         errdefer node_list.deinit(allocator);
+
+//         try node_list.append(allocator, root_node);
+
+//         // Check DequantizeLinear -> Pad
+//         if (root_node.next.items.len != 1) {
+//             node_list.deinit(allocator);
+//             return null;
+//         }
+
+//         const pad_node = root_node.next.items[0];
+//         if (pad_node.op != .clip) {
+//             node_list.deinit(allocator);
+//             return null;
+//         }
+
+//         try node_list.append(allocator, pad_node);
+
+//         std.debug.print(" -> Found complete Conv->Clip pattern!", .{});
+
+//         return node_list;
+//     }
+
+//     /// Pattern fusion function
+//     pub fn fn_pattern_fusion(graph: *GraphZant, node_list: std.ArrayList(*NodeZant)) anyerror!NodeZant {
+//         _ = graph; // Not used in this sequential pattern
+
+//         // Validate the pattern
+//         if (node_list.items.len != 2) return error.InvalidNumberOfOps;
+//         if (node_list.items[0].op != .conv) return error.UnexpectedOpAtPos0;
+//         if (node_list.items[1].op != .clip) return error.UnexpectedOpAtPos1;
+
+//         const last_node = node_list.items[1]; // Clip
+
+//         // Clone the next list instead of direct reference
+//         var cloned_next: std.ArrayList(*NodeZant) = .empty;
+//         for (last_node.next.items) |next_node| {
+//             try cloned_next.append(allocator, next_node);
+//         }
+
+//         return NodeZant{
+//             .name = try NodeZant_lib.getFusedOpsName(node_list),
+//             .op_type = try NodeZant_lib.getFusedOpsType(node_list),
+//             .op = Op_union{
+//                 .fused_Conv_Clip = try init_from_conv_clip(
+//                     node_list.items[0].nodeProto.?.*, //Conv proto node
+//                     node_list.items[1].nodeProto.?.*, //Clip proto node
+//                 ),
+//             },
+//             .next = cloned_next,
+//             .nodeProto = null,
+//             .ready = false,
+//             .is_fused = true,
+//         };
+//     }
+
+//     /// Pattern substitution function
+//     pub fn fn_pattern_sobstitution(graph: *GraphZant, fused_node: *NodeZant, node_list: std.ArrayList(*NodeZant)) anyerror!void {
+//         // Validate inputs
+//         if (node_list.items.len != 2) return error.InvalidPatternLength;
+
+//         const first_node = node_list.items[0]; // DequantizeLinear node
+//         const last_node = node_list.items[1]; // QLinearConv node
+
+//         // Step 1: Find all predecessor nodes that point to the first node
+//         const predecessors = try graph.get_predecessors(first_node);
+
+//         // Step 2: Update predecessor nodes to point to fused_node
+//         for (predecessors.items) |predecessor| {
+//             for (predecessor.next.items, 0..) |next_node, i| {
+//                 if (next_node == first_node) {
+//                     predecessor.next.items[i] = fused_node;
+//                 }
+//             }
+//         }
+
+//         // Step 3: Set up fused node's successors
+//         if (fused_node.next.items.len == 0) {
+//             for (last_node.next.items) |successor| {
+//                 try fused_node.next.append(allocator, successor);
+//             }
+//         }
+
+//         // Step 4: Remove old nodes from graph
+//         try graph.removeNodes(node_list);
+
+//         // Step 5: Add fused node to graph
+//         try graph.nodes.append(allocator, fused_node);
+//     }
+// };

--- a/tests/Core/Tensor/TensorMath/test_op_concatenate 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_concatenate 2.zig
@@ -1,0 +1,416 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+const TensorError = zant.utils.error_handler.TensorError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "Empty tensor list error" {
+    tests_log.info("\n     test: Empty tensor list error", .{});
+    const empty_shapes: []const []const usize = &[_][]const usize{};
+    try std.testing.expectError(TensorMathError.EmptyTensorList, TensMath.get_concatenate_output_shape(empty_shapes, 0));
+}
+
+test "get_concatenate_output_shape" {
+    tests_log.info("\n     test: get_concatenate_output_shape \n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Test concatenation along axis 0
+    var shapes = [_][]const usize{
+        &[_]usize{ 2, 3 },
+        &[_]usize{ 3, 3 },
+        &[_]usize{ 1, 3 },
+    };
+
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes, 0);
+        defer allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 6), output_shape[0]); // 2 + 3 + 1
+        try std.testing.expectEqual(@as(usize, 3), output_shape[1]); // unchanged
+    }
+
+    // Test concatenation along axis 1
+    const shapes_axis1 = [_][]const usize{
+        &[_]usize{ 2, 3 },
+        &[_]usize{ 2, 2 },
+    };
+
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes_axis1, 1);
+        defer allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]); // unchanged
+        try std.testing.expectEqual(@as(usize, 5), output_shape[1]); // 3 + 2
+    }
+
+    // Test concatenation along negative axis
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes_axis1, -1);
+        defer allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]); // unchanged
+        try std.testing.expectEqual(@as(usize, 5), output_shape[1]); // 3 + 2
+    }
+
+    // Test error cases
+    var empty_shapes = [_][]const usize{};
+    try std.testing.expectError(TensorMathError.EmptyTensorList, TensMath.get_concatenate_output_shape(&empty_shapes, 0));
+
+    var mismatched_shapes = [_][]const usize{
+        &[_]usize{ 2, 3 },
+        &[_]usize{ 3, 4 }, // different non-concat dimension
+    };
+    try std.testing.expectError(TensorError.MismatchedShape, TensMath.get_concatenate_output_shape(&mismatched_shapes, 0));
+}
+
+test "Concatenate tensors along axis 0" {
+    tests_log.info("\n     test: Concatenate tensors along axis 0", .{});
+    var allocator = pkgAllocator.allocator;
+
+    var inputArray1: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+
+    var inputArray2: [2][2]f32 = [_][2]f32{
+        [_]f32{ 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+
+    var shape: [2]usize = [_]usize{ 2, 2 }; // 2x2 matrix for both tensors
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray1, &shape);
+    defer t1.deinit();
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray2, &shape);
+    defer t2.deinit();
+
+    var tensors = [_]Tensor(f32){ t1, t2 };
+
+    var result_tensor = try TensMath.concatenate(f32, &allocator, &tensors, 0);
+    defer result_tensor.deinit();
+
+    const expected_data: [4][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+        [_]f32{ 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+
+    try std.testing.expect(result_tensor.shape[0] == 4);
+    try std.testing.expect(result_tensor.shape[1] == 2);
+
+    for (0..4) |i| {
+        for (0..2) |j| {
+            //tests_log.debug("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 2 + j] });
+            try std.testing.expect(result_tensor.data[i * 2 + j] == expected_data[i][j]);
+        }
+    }
+}
+
+test "Concatenate tensors along axis 1" {
+    tests_log.info("\n     test: Concatenate tensors along axis 1", .{});
+    var allocator = pkgAllocator.allocator;
+
+    var inputArray1: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+
+    var inputArray2: [2][2]f32 = [_][2]f32{
+        [_]f32{ 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+
+    var shape: [2]usize = [_]usize{ 2, 2 }; // 2x2 matrix for both tensors
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray1, &shape);
+    defer t1.deinit();
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray2, &shape);
+    defer t2.deinit();
+
+    var tensors = [_]Tensor(f32){ t1, t2 };
+
+    var result_tensor = try TensMath.concatenate(f32, &allocator, &tensors, 1);
+    defer result_tensor.deinit();
+
+    const expected_data: [2][4]f32 = [_][4]f32{
+        [_]f32{ 1.0, 2.0, 5.0, 6.0 },
+        [_]f32{ 3.0, 4.0, 7.0, 8.0 },
+    };
+    result_tensor.print();
+
+    try std.testing.expect(result_tensor.shape[0] == 2);
+    try std.testing.expect(result_tensor.shape[1] == 4);
+
+    for (0..2) |i| {
+        for (0..4) |j| {
+            //tests_log.info("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 4 + j] });
+            try std.testing.expect(result_tensor.data[i * 4 + j] == expected_data[i][j]);
+        }
+    }
+}
+
+test "Concatenate tensors along negative axis" {
+    tests_log.info("\n     test: Concatenate tensors along negative axis", .{});
+    var allocator = std.testing.allocator;
+
+    var inputArray1: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+
+    var inputArray2: [2][2]f32 = [_][2]f32{
+        [_]f32{ 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+
+    var shape: [2]usize = [_]usize{ 2, 2 }; // 2x2 matrix for both tensors
+
+    // Initialize tensors from arrays
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray1, &shape);
+    defer t1.deinit();
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray2, &shape);
+    defer t2.deinit();
+
+    var tensors = [_]Tensor(f32){ t1, t2 };
+
+    // Perform concatenation along axis -1 (equivalent to axis 1)
+    var result_tensor = try TensMath.concatenate(f32, &allocator, &tensors, -1);
+    defer result_tensor.deinit();
+
+    const expected_data: [2][4]f32 = [_][4]f32{
+        [_]f32{ 1.0, 2.0, 5.0, 6.0 },
+        [_]f32{ 3.0, 4.0, 7.0, 8.0 },
+    };
+
+    try std.testing.expect(result_tensor.shape[0] == 2);
+    try std.testing.expect(result_tensor.shape[1] == 4);
+
+    for (0..2) |i| {
+        for (0..4) |j| {
+            try std.testing.expect(result_tensor.data[i * 4 + j] == expected_data[i][j]);
+        }
+    }
+}
+
+test "Concatenate 3D tensors along axis 2" {
+    tests_log.info("\n     test: Concatenate 3D tensors along axis 2", .{});
+    var allocator = std.testing.allocator;
+
+    // Tensor A: shape [2, 2, 2]
+    var inputArrayA: [2][2][2]f32 = [_][2][2]f32{
+        [_][2]f32{ [_]f32{ 1.0, 2.0 }, [_]f32{ 3.0, 4.0 } },
+        [_][2]f32{ [_]f32{ 5.0, 6.0 }, [_]f32{ 7.0, 8.0 } },
+    };
+    var shapeA: [3]usize = [_]usize{ 2, 2, 2 };
+    var tA = try Tensor(f32).fromArray(&allocator, &inputArrayA, &shapeA);
+    defer tA.deinit();
+
+    // Tensor B: shape [2, 2, 3]
+    var inputArrayB: [2][2][3]f32 = [_][2][3]f32{
+        [_][3]f32{ [_]f32{ 9.0, 10.0, 11.0 }, [_]f32{ 12.0, 13.0, 14.0 } },
+        [_][3]f32{ [_]f32{ 15.0, 16.0, 17.0 }, [_]f32{ 18.0, 19.0, 20.0 } },
+    };
+    var shapeB: [3]usize = [_]usize{ 2, 2, 3 };
+    var tB = try Tensor(f32).fromArray(&allocator, &inputArrayB, &shapeB);
+    defer tB.deinit();
+
+    var tensors = [_]Tensor(f32){ tA, tB };
+
+    // Perform concatenation along axis 2
+    var result_tensor = try TensMath.concatenate(f32, &allocator, &tensors, 2);
+    defer result_tensor.deinit();
+
+    const expected_data: [2][2][5]f32 = [_][2][5]f32{
+        [_][5]f32{
+            [_]f32{ 1.0, 2.0, 9.0, 10.0, 11.0 },
+            [_]f32{ 3.0, 4.0, 12.0, 13.0, 14.0 },
+        },
+        [_][5]f32{
+            [_]f32{ 5.0, 6.0, 15.0, 16.0, 17.0 },
+            [_]f32{ 7.0, 8.0, 18.0, 19.0, 20.0 },
+        },
+    };
+
+    try std.testing.expect(result_tensor.shape[0] == 2);
+    try std.testing.expect(result_tensor.shape[1] == 2);
+    try std.testing.expect(result_tensor.shape[2] == 5);
+
+    for (0..2) |i| {
+        for (0..2) |j| {
+            for (0..5) |k| {
+                try std.testing.expect(result_tensor.data[i * 2 * 5 + j * 5 + k] == expected_data[i][j][k]);
+            }
+        }
+    }
+}
+
+test "Concatenate tensors with mismatched shapes" {
+    tests_log.info("\n     test: Concatenate tensors with mismatched shapes", .{});
+    var allocator = pkgAllocator.allocator;
+
+    var inputArray1: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+
+    var inputArray2: [2][3]f32 = [_][3]f32{
+        [_]f32{ 5.0, 6.0, 7.0 },
+        [_]f32{ 8.0, 9.0, 10.0 },
+    };
+
+    var shape1: [2]usize = [_]usize{ 2, 2 };
+    var shape2: [2]usize = [_]usize{ 2, 3 };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray1, &shape1);
+    defer t1.deinit();
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray2, &shape2);
+    defer t2.deinit();
+
+    var tensors = [_]Tensor(f32){ t1, t2 };
+
+    // Should fail when trying to concatenate along axis 0 due to mismatched shapes
+    try std.testing.expectError(TensorError.MismatchedShape, TensMath.concatenate(f32, &allocator, &tensors, 0));
+
+    // Should succeed when concatenating along axis 1
+    var result = try TensMath.concatenate(f32, &allocator, &tensors, 1);
+    defer result.deinit();
+
+    try std.testing.expect(result.shape[0] == 2);
+    try std.testing.expect(result.shape[1] == 5);
+
+    const expected_data: [2][5]f32 = [_][5]f32{
+        [_]f32{ 1.0, 2.0, 5.0, 6.0, 7.0 },
+        [_]f32{ 3.0, 4.0, 8.0, 9.0, 10.0 },
+    };
+
+    for (0..2) |i| {
+        for (0..5) |j| {
+            try std.testing.expect(result.data[i * 5 + j] == expected_data[i][j]);
+        }
+    }
+}
+
+test "Concatenate tensors with invalid axis" {
+    tests_log.info("\n     test: Concatenate tensors with invalid axis", .{});
+    var allocator = pkgAllocator.allocator;
+
+    var inputArray1: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+
+    var inputArray2: [2][2]f32 = [_][2]f32{
+        [_]f32{ 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+
+    var shape: [2]usize = [_]usize{ 2, 2 };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray1, &shape);
+    defer t1.deinit();
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray2, &shape);
+    defer t2.deinit();
+
+    var tensors = [_]Tensor(f32){ t1, t2 };
+
+    // Should fail when axis is out of bounds
+    try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.concatenate(f32, &allocator, &tensors, 2));
+    try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.concatenate(f32, &allocator, &tensors, -3));
+}
+
+test "get_concatenate_output_shape - 3D tensors" {
+    tests_log.info("\n     test: get_concatenate_output_shape - 3D tensors", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Test shapes for 3D tensors
+    var shapes = [_][]const usize{
+        &[_]usize{ 2, 2, 2 },
+        &[_]usize{ 2, 2, 3 },
+    };
+
+    // Test concatenation along last axis (axis 2)
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes, 2);
+        defer allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 3), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[1]);
+        try std.testing.expectEqual(@as(usize, 5), output_shape[2]); // 2 + 3
+    }
+
+    // Test concatenation along middle axis (axis 1)
+    var shapes_axis1 = [_][]const usize{
+        &[_]usize{ 2, 2, 3 },
+        &[_]usize{ 2, 3, 3 },
+    };
+
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes_axis1, 1);
+        defer allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 3), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 5), output_shape[1]); // 2 + 3
+        try std.testing.expectEqual(@as(usize, 3), output_shape[2]);
+    }
+}
+
+test "get_concatenate_output_shape - mismatched shapes" {
+    tests_log.info("\n     test: get_concatenate_output_shape - mismatched shapes", .{});
+
+    // Test shapes with mismatched dimensions
+    var shapes = [_][]const usize{
+        &[_]usize{ 2, 2 },
+        &[_]usize{ 2, 3 },
+    };
+
+    // Should fail along axis 0 (mismatched non-concat dimensions)
+    try std.testing.expectError(TensorError.MismatchedShape, TensMath.get_concatenate_output_shape(&shapes, 0));
+
+    // Should succeed along axis 1
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes, 1);
+        defer pkgAllocator.allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 5), output_shape[1]); // 2 + 3
+    }
+}
+
+//Mismatched rank now supported
+
+test "get_concatenate_output_shape - invalid axis" {
+    tests_log.info("\n     test: get_concatenate_output_shape - invalid axis", .{});
+
+    var shapes = [_][]const usize{
+        &[_]usize{ 2, 2 },
+        &[_]usize{ 2, 2 },
+    };
+
+    // Test positive out of bounds axis
+    try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.get_concatenate_output_shape(&shapes, 2));
+
+    // Test negative out of bounds axis
+    try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.get_concatenate_output_shape(&shapes, -3));
+
+    // Test valid negative axis
+    {
+        const output_shape = try TensMath.get_concatenate_output_shape(&shapes, -1);
+        defer pkgAllocator.allocator.free(output_shape);
+
+        try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 4), output_shape[1]); // 2 + 2
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_op_conv_clip.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_conv_clip.zig
@@ -1,0 +1,1012 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+
+const Uops = zant.uops;
+const UOpBuilder = Uops.UOpBuilder;
+const DType = Uops.DType;
+const Any = Uops.Any;
+const lowerConv2d = zant.core.tensor.math_standard.lowerConv2d;
+
+const tests_log = std.log.scoped(.test_conv_clip);
+
+// ---------------------------------------------------------------
+// -------------------- TESTS FOR CONV+CLIP ----------------------
+// ---------------------------------------------------------------
+// Conv+Clip tests for convolution followed by clipping operation
+
+// Test clipping values above max
+test "Conv_Clip - values clipped to max" {
+    tests_log.info("\n     test: Conv_Clip - values clipped to max\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Input: all 1s
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    // Kernel: all 1s (will produce value 4)
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Min and Max tensors
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{-10.0};
+    var maxArray: [1]f32 = [_]f32{2.0}; // Clip to max 2.0
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    // Create output tensor with correct shape [1, 1, 2, 2]
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Output shape: [1, 1, 2, 2]
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[0]);
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[1]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[3]);
+
+    // Without clip would be 4, with clip becomes 2.0 (max)
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 2.0), val);
+    }
+
+    tests_log.info("Values correctly clipped to max\n", .{});
+}
+
+// Test clipping values below min
+test "Conv_Clip - values clipped to min" {
+    tests_log.info("\n     test: Conv_Clip - values clipped to min\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Input: all 1s
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    // Kernel: all -1s (will produce value -4)
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ -1, -1 },
+                [_]f32{ -1, -1 },
+            },
+        },
+    };
+
+    // Min and Max tensors
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{-2.0}; // Clip to min -2.0
+    var maxArray: [1]f32 = [_]f32{10.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    // Create output tensor with correct shape [1, 1, 2, 2]
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Without clip would be -4, with clip becomes -2.0 (min)
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, -2.0), val);
+    }
+
+    tests_log.info("Values correctly clipped to min\n", .{});
+}
+
+// Test values within clip range (no clipping needed)
+test "Conv_Clip - values within range unchanged" {
+    tests_log.info("\n     test: Conv_Clip - values within range unchanged\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Input: all 1s
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    // Kernel: all 1s (will produce value 4)
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Min and Max tensors with wide range
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{10.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Value 4 is within [0, 10] range
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 4), val);
+    }
+
+    tests_log.info("Values within range preserved correctly\n", .{});
+}
+
+// Test mixed values with different clipping behaviors
+test "Conv_Clip - mixed values with selective clipping" {
+    tests_log.info("\n     test: Conv_Clip - mixed values with selective clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Input with variable values
+    var input_shape: [4]usize = [_]usize{ 1, 1, 4, 4 };
+    var inputArray: [1][1][4][4]f32 = [_][1][4][4]f32{
+        [_][4][4]f32{
+            [_][4]f32{
+                [_]f32{ 1, -1, 2, 1 },
+                [_]f32{ 0, 3, -2, 1 },
+                [_]f32{ 2, 1, 4, 0 },
+                [_]f32{ -1, 0, 1, 2 },
+            },
+        },
+    };
+
+    // Kernel: mix of positive and negative
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 0.5 },
+                [_]f32{ 0.5, 1 },
+            },
+        },
+    };
+
+    // Clip range [-2, 3]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{-2.0};
+    var maxArray: [1]f32 = [_]f32{3.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 3, 3 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Output shape: [1, 1, 3, 3]
+    try std.testing.expectEqual(@as(usize, 3), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 3), output_tensor.shape[3]);
+
+    // All values should be within [-2, 3]
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= -2.0);
+        try std.testing.expect(val <= 3.0);
+    }
+
+    tests_log.info("Mixed values clipped correctly\n", .{});
+}
+
+// Test with bias and clipping
+test "Conv_Clip - with bias affecting clip behavior" {
+    tests_log.info("\n     test: Conv_Clip - with bias affecting clip behavior\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Bias: 3 (conv result 4 + bias 3 = 7, will be clipped to 5)
+    var bias_shape: [1]usize = [_]usize{1};
+    var biasArray: [1]f32 = [_]f32{3};
+
+    // Clip range [0, 5]
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{5.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var bias_tensor = try Tensor(f32).fromArray(&allocator, &biasArray, &bias_shape);
+    defer bias_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &bias_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &bias_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, &bias_tensor, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Result should be 5.0 (7.0 clipped to max 5.0)
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 5.0), val);
+    }
+
+    tests_log.info("Bias with clipping handled correctly\n", .{});
+}
+
+// Test with only max clipping (no min)
+test "Conv_Clip - with only max bound" {
+    tests_log.info("\n     test: Conv_Clip - with only max bound\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Only max, no min
+    var max_shape: [1]usize = [_]usize{1};
+    var maxArray: [1]f32 = [_]f32{2.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &max_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, null, &max_tensor);
+
+    // Without clip would be 4, with max=2 becomes 2
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 2.0), val);
+    }
+
+    tests_log.info("Max-only clipping works correctly\n", .{});
+}
+
+// Test multi-channel with clipping
+test "Conv_Clip - multi-channel with clipping" {
+    tests_log.info("\n     test: Conv_Clip - multi-channel with clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // 1 batch, 2 input channels, 3x3
+    var input_shape: [4]usize = [_]usize{ 1, 2, 3, 3 };
+    var inputArray: [1][2][3][3]f32 = [_][2][3][3]f32{
+        [_][3][3]f32{
+            // Channel 1
+            [_][3]f32{
+                [_]f32{ 2, 3, 2 },
+                [_]f32{ 1, 4, 1 },
+                [_]f32{ 2, 3, 2 },
+            },
+            // Channel 2
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    // 1 filter, 2 input channels, 2x2 kernel
+    var kernel_shape: [4]usize = [_]usize{ 1, 2, 2, 2 };
+    var kernelArray: [1][2][2][2]f32 = [_][2][2][2]f32{
+        [_][2][2]f32{
+            // Channel 1
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+            // Channel 2
+            [_][2]f32{
+                [_]f32{ 0.5, 0.5 },
+                [_]f32{ 0.5, 0.5 },
+            },
+        },
+    };
+
+    // Clip range [0, 10]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{10.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Output shape: [1, 1, 2, 2]
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[0]);
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[1]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[3]);
+
+    // All values should be within [0, 10]
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= 0.0);
+        try std.testing.expect(val <= 10.0);
+    }
+
+    tests_log.info("Multi-channel with clipping works correctly\n", .{});
+}
+
+// Test with padding and clipping
+test "Conv_Clip - SAME_UPPER padding with clipping" {
+    tests_log.info("\n     test: Conv_Clip - SAME_UPPER padding with clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 4, 4 };
+    var inputArray: [1][1][4][4]f32 = [_][1][4][4]f32{
+        [_][4][4]f32{
+            [_][4]f32{
+                [_]f32{ 2, 2, 2, 2 },
+                [_]f32{ 2, 2, 2, 2 },
+                [_]f32{ 2, 2, 2, 2 },
+                [_]f32{ 2, 2, 2, 2 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var kernelArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+                [_]f32{ 1, 1, 1 },
+            },
+        },
+    };
+
+    // Clip range [0, 12]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{12.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const auto_pad = "SAME_UPPER";
+
+    var output_shape = [_]usize{ 1, 1, 4, 4 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, null, null, null, auto_pad, &min_tensor, &max_tensor);
+
+    try std.testing.expectEqual(@as(usize, 4), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 4), output_tensor.shape[3]);
+
+    // All values should be within [0, 12]
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= 0.0);
+        try std.testing.expect(val <= 12.0);
+    }
+
+    tests_log.info("SAME_UPPER padding with clipping works correctly\n", .{});
+}
+
+// Test with stride, dilation, and clipping
+test "Conv_Clip - stride and dilation with clipping" {
+    tests_log.info("\n     test: Conv_Clip - stride and dilation with clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 6, 6 };
+    var inputArray: [1][1][6][6]f32 = [_][1][6][6]f32{
+        [_][6][6]f32{
+            [_][6]f32{
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1, 1 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Clip range [0, 3]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{3.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{2};
+    const dilations = [_]usize{2};
+
+    // Output con stride=2, dilation=2: [1, 1, 2, 2]
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, null, &dilations, null, null, &min_tensor, &max_tensor);
+
+    // All values should be within [0, 3] and clipped to 3 (result would be 4 without clip)
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 3.0), val);
+    }
+
+    tests_log.info("Stride and dilation with clipping works correctly\n", .{});
+}
+
+// Test depthwise convolution with clipping
+test "Conv_Clip - depthwise with clipping" {
+    tests_log.info("\n     test: Conv_Clip - depthwise with clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // 1 batch, 2 input channels, 3x3
+    var input_shape: [4]usize = [_]usize{ 1, 2, 3, 3 };
+    var inputArray: [1][2][3][3]f32 = [_][2][3][3]f32{
+        [_][3][3]f32{
+            // Channel 1
+            [_][3]f32{
+                [_]f32{ 2, 2, 2 },
+                [_]f32{ 2, 2, 2 },
+                [_]f32{ 2, 2, 2 },
+            },
+            // Channel 2
+            [_][3]f32{
+                [_]f32{ 3, 3, 3 },
+                [_]f32{ 3, 3, 3 },
+                [_]f32{ 3, 3, 3 },
+            },
+        },
+    };
+
+    // 2 filters, 1 channel each (depthwise)
+    var kernel_shape: [4]usize = [_]usize{ 2, 1, 2, 2 };
+    var kernelArray: [2][1][2][2]f32 = [_][1][2][2]f32{
+        // Filter 1
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+        // Filter 2
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Clip range [0, 10]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{10.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 2, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, 2, null, &min_tensor, &max_tensor);
+
+    // Output shape: [1, 2, 2, 2]
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[0]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[1]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[3]);
+
+    // All values should be within [0, 10]
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= 0.0);
+        try std.testing.expect(val <= 10.0);
+    }
+
+    tests_log.info("Depthwise with clipping works correctly\n", .{});
+}
+
+// Test multi-batch with clipping
+test "Conv_Clip - multi-batch with clipping" {
+    tests_log.info("\n     test: Conv_Clip - multi-batch with clipping\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // 2 batches, 1 channel, 3x3
+    var input_shape: [4]usize = [_]usize{ 2, 1, 3, 3 };
+    var inputArray: [2][1][3][3]f32 = [_][1][3][3]f32{
+        // Batch 1
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 3, 3, 3 },
+                [_]f32{ 3, 3, 3 },
+                [_]f32{ 3, 3, 3 },
+            },
+        },
+        // Batch 2
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 2, 2, 2 },
+                [_]f32{ 2, 2, 2 },
+                [_]f32{ 2, 2, 2 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    // Clip range [0, 10]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{10.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 2, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // Output shape: [2, 1, 2, 2]
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[0]);
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[1]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 2), output_tensor.shape[3]);
+
+    // Batch 1: 3*4 = 12, clipped to 10
+    // Batch 2: 2*4 = 8, within range
+    for (0..4) |i| {
+        try std.testing.expectEqual(@as(f32, 10.0), output_tensor.data[i]);
+    }
+    for (4..8) |i| {
+        try std.testing.expectEqual(@as(f32, 8.0), output_tensor.data[i]);
+    }
+
+    tests_log.info("Multi-batch with clipping works correctly\n", .{});
+}
+
+// Test extreme clipping (min = max)
+test "Conv_Clip - extreme clipping min equals max" {
+    tests_log.info("\n     test: Conv_Clip - extreme clipping min equals max\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 3, 3 };
+    var inputArray: [1][1][3][3]f32 = [_][1][3][3]f32{
+        [_][3][3]f32{
+            [_][3]f32{
+                [_]f32{ 1, 2, 3 },
+                [_]f32{ 4, 5, 6 },
+                [_]f32{ 7, 8, 9 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 0.1, 0.2 },
+                [_]f32{ 0.3, 0.4 },
+            },
+        },
+    };
+
+    // Min = Max = 5.0 (all values become 5.0)
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{5.0};
+    var maxArray: [1]f32 = [_]f32{5.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // All values should be exactly 5.0
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 5.0), val);
+    }
+
+    tests_log.info("Extreme clipping (min=max) works correctly\n", .{});
+}
+
+// Test with conv_clip_lean
+test "Conv_Clip - conv_clip_lean with bias and dilation" {
+    tests_log.info("\n     test: Conv_Clip - conv_clip_lean with bias and dilation\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 5, 5 };
+    var inputArray: [1][1][5][5]f32 = [_][1][5][5]f32{
+        [_][5][5]f32{
+            [_][5]f32{
+                [_]f32{ 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1 },
+                [_]f32{ 1, 1, 1, 1, 1 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 1, 1 },
+                [_]f32{ 1, 1 },
+            },
+        },
+    };
+
+    var bias_shape: [1]usize = [_]usize{1};
+    var biasArray: [1]f32 = [_]f32{1};
+
+    // Clip range [0, 4]
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{4.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var bias_tensor = try Tensor(f32).fromArray(&allocator, &biasArray, &bias_shape);
+    defer bias_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &bias_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &bias_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const dilations = [_]usize{2};
+
+    var output_shape = [_]usize{ 1, 1, 3, 3 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, &bias_tensor, &stride, null, &dilations, null, null, &min_tensor, &max_tensor);
+
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[0]);
+    try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[1]);
+    try std.testing.expectEqual(@as(usize, 3), output_tensor.shape[2]);
+    try std.testing.expectEqual(@as(usize, 3), output_tensor.shape[3]);
+
+    // Each output: 4 (dilated kernel) + 1 (bias) = 5, clipped to 4
+    for (output_tensor.data) |val| {
+        try std.testing.expectEqual(@as(f32, 4.0), val);
+    }
+
+    tests_log.info("Conv_clip_lean with bias, dilation and clipping works correctly\n", .{});
+}
+
+// Test zero-centered clipping (symmetric range)
+test "Conv_Clip - symmetric clipping range" {
+    tests_log.info("\n     test: Conv_Clip - symmetric clipping range\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape: [4]usize = [_]usize{ 1, 1, 4, 4 };
+    var inputArray: [1][1][4][4]f32 = [_][1][4][4]f32{
+        [_][4][4]f32{
+            [_][4]f32{
+                [_]f32{ -2, 3, -1, 2 },
+                [_]f32{ 1, -3, 2, -1 },
+                [_]f32{ -1, 2, 3, 1 },
+                [_]f32{ 2, -1, -2, 3 },
+            },
+        },
+    };
+
+    var kernel_shape: [4]usize = [_]usize{ 1, 1, 2, 2 };
+    var kernelArray: [1][1][2][2]f32 = [_][1][2][2]f32{
+        [_][2][2]f32{
+            [_][2]f32{
+                [_]f32{ 0.5, -0.5 },
+                [_]f32{ -0.5, 0.5 },
+            },
+        },
+    };
+
+    // Symmetric clip range [-3, 3]
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{-3.0};
+    var maxArray: [1]f32 = [_]f32{3.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 1, 3, 3 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, null, null, &min_tensor, &max_tensor);
+
+    // All values should be within [-3, 3]
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= -3.0);
+        try std.testing.expect(val <= 3.0);
+    }
+
+    tests_log.info("Symmetric clipping range works correctly\n", .{});
+}
+
+// ===============================================================
+// -------------------- EDGE CASES TESTS -------------------------
+// ===============================================================
+
+// Edge case: ReLU6 pattern (Clip(0, 6)) - Common in MobileNet v2
+test "Conv_Clip - ReLU6 pattern (MobileNet v2)" {
+    tests_log.info("\n     test: Conv_Clip - ReLU6 pattern (MobileNet v2)\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    // Simulating a typical depthwise separable convolution output
+    var input_shape: [4]usize = [_]usize{ 1, 3, 4, 4 };
+    var inputArray: [1][3][4][4]f32 = undefined;
+
+    // Fill with varied values to test ReLU6 behavior
+    for (0..3) |c| {
+        for (0..4) |h| {
+            for (0..4) |w| {
+                const val = @as(f32, @floatFromInt(c * 16 + h * 4 + w)) * 0.5 - 5.0;
+                inputArray[0][c][h][w] = val;
+            }
+        }
+    }
+
+    // 3 filters, 1 channel each (depthwise)
+    var kernel_shape: [4]usize = [_]usize{ 3, 1, 3, 3 };
+    var kernelArray: [3][1][3][3]f32 = undefined;
+
+    for (0..3) |f| {
+        for (0..3) |h| {
+            for (0..3) |w| {
+                kernelArray[f][0][h][w] = 0.1;
+            }
+        }
+    }
+
+    // ReLU6: Clip(0, 6)
+    var min_shape: [1]usize = [_]usize{1};
+    var minArray: [1]f32 = [_]f32{0.0};
+    var maxArray: [1]f32 = [_]f32{6.0};
+
+    var input_tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &input_shape);
+    defer input_tensor.deinit();
+    var kernel_tensor = try Tensor(f32).fromArray(&allocator, &kernelArray, &kernel_shape);
+    defer kernel_tensor.deinit();
+    var min_tensor = try Tensor(f32).fromArray(&allocator, &minArray, &min_shape);
+    defer min_tensor.deinit();
+    var max_tensor = try Tensor(f32).fromArray(&allocator, &maxArray, &min_shape);
+    defer max_tensor.deinit();
+
+    const stride = [_]usize{1};
+    const pads = [_]usize{ 0, 0, 0, 0 };
+
+    var output_shape = [_]usize{ 1, 3, 2, 2 };
+    var output_tensor = try Tensor(f32).fromShape(&allocator, &output_shape);
+    defer output_tensor.deinit();
+
+    try TensMath.conv_clip_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, &pads, null, 3, null, &min_tensor, &max_tensor);
+
+    // Verify all values are in [0, 6] range (ReLU6)
+    for (output_tensor.data) |val| {
+        try std.testing.expect(val >= 0.0);
+        try std.testing.expect(val <= 6.0);
+    }
+
+    tests_log.info("ReLU6 pattern (Clip(0,6)) works correctly\n", .{});
+}

--- a/tests/Core/Tensor/TensorMath/test_op_gather.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_gather.zig
@@ -8,235 +8,235 @@ const TensorMathError = zant.utils.error_handler.TensorMathError;
 
 const tests_log = std.log.scoped(.test_lib_shape);
 
-// test "gather along axis 0 and axis 1" {
-//     const allocator = pkgAllocator.allocator;
+test "gather along axis 0 and axis 1" {
+    const allocator = pkgAllocator.allocator;
 
-//     // -------------------------------------------------------------------------------------
-//     // Test Case 1: Gather Along Axis 0
-//     // -------------------------------------------------------------------------------------
-//     tests_log.info("\n     test: gather along axis 0", .{});
+    // -------------------------------------------------------------------------------------
+    // Test Case 1: Gather Along Axis 0
+    // -------------------------------------------------------------------------------------
+    tests_log.info("\n     test: gather along axis 0", .{});
 
-//     // Initialize input tensor: 3x3 matrix
-//     var inputArray0: [3][3]u8 = [_][3]u8{
-//         [_]u8{ 1, 2, 3 },
-//         [_]u8{ 4, 5, 6 },
-//         [_]u8{ 7, 8, 9 },
-//     };
-//     var inputShape0: [2]usize = [_]usize{ 3, 3 };
-//     var inputTensor0 = try Tensor(u8).fromArray(&allocator, &inputArray0, &inputShape0);
-//     defer inputTensor0.deinit();
+    // Initialize input tensor: 3x3 matrix
+    var inputArray0: [3][3]u8 = [_][3]u8{
+        [_]u8{ 1, 2, 3 },
+        [_]u8{ 4, 5, 6 },
+        [_]u8{ 7, 8, 9 },
+    };
+    var inputShape0: [2]usize = [_]usize{ 3, 3 };
+    var inputTensor0 = try Tensor(u8).fromArray(&allocator, &inputArray0, &inputShape0);
+    defer inputTensor0.deinit();
 
-//     // Initialize indices tensor: [0, 2]
-//     var indicesArray0: [2]usize = [_]usize{ 0, 2 };
-//     var indicesShape0: [1]usize = [_]usize{2};
-//     var indicesTensor0 = try Tensor(usize).fromArray(&allocator, &indicesArray0, &indicesShape0);
-//     defer indicesTensor0.deinit();
+    // Initialize indices tensor: [0, 2]
+    var indicesArray0: [2]usize = [_]usize{ 0, 2 };
+    var indicesShape0: [1]usize = [_]usize{2};
+    var indicesTensor0 = try Tensor(usize).fromArray(&allocator, &indicesArray0, &indicesShape0);
+    defer indicesTensor0.deinit();
 
-//     // Perform gather along axis 0
-//     var gatheredTensor0 = try TensMath.gather(u8, &inputTensor0, &indicesTensor0, 0);
-//     defer gatheredTensor0.deinit();
+    // Perform gather along axis 0
+    var gatheredTensor0 = try TensMath.gather(u8, &inputTensor0, &indicesTensor0, 0);
+    defer gatheredTensor0.deinit();
 
-//     // Expected output tensor: [1,2,3,7,8,9], shape [2,3]
-//     const expectedData0: [6]u8 = [_]u8{ 1, 2, 3, 7, 8, 9 };
-//     const expectedShape0: [2]usize = [_]usize{ 2, 3 };
+    // Expected output tensor: [1,2,3,7,8,9], shape [2,3]
+    const expectedData0: [6]u8 = [_]u8{ 1, 2, 3, 7, 8, 9 };
+    const expectedShape0: [2]usize = [_]usize{ 2, 3 };
 
-//     // Check shape
-//     try std.testing.expect(gatheredTensor0.shape.len == expectedShape0.len);
-//     for (0..expectedShape0.len) |i| {
-//         try std.testing.expect(gatheredTensor0.shape[i] == expectedShape0[i]);
-//     }
+    // Check shape
+    try std.testing.expect(gatheredTensor0.shape.len == expectedShape0.len);
+    for (0..expectedShape0.len) |i| {
+        try std.testing.expect(gatheredTensor0.shape[i] == expectedShape0[i]);
+    }
 
-//     // Check data
-//     try std.testing.expect(gatheredTensor0.size == 6);
-//     for (0..gatheredTensor0.size) |i| {
-//         try std.testing.expect(gatheredTensor0.data[i] == expectedData0[i]);
-//     }
+    // Check data
+    try std.testing.expect(gatheredTensor0.size == 6);
+    for (0..gatheredTensor0.size) |i| {
+        try std.testing.expect(gatheredTensor0.data[i] == expectedData0[i]);
+    }
 
-//     // -------------------------------------------------------------------------------------
-//     // Test Case 2: Gather Along Axis 1
-//     // -------------------------------------------------------------------------------------
-//     tests_log.info("\n     test: gather along axis 1", .{});
+    // -------------------------------------------------------------------------------------
+    // Test Case 2: Gather Along Axis 1
+    // -------------------------------------------------------------------------------------
+    tests_log.info("\n     test: gather along axis 1", .{});
 
-//     var inputArray1: [2][4]u8 = [_][4]u8{
-//         [_]u8{ 10, 20, 30, 40 },
-//         [_]u8{ 50, 60, 70, 80 },
-//     };
-//     var inputShape1: [2]usize = [_]usize{ 2, 4 };
-//     var inputTensor1 = try Tensor(u8).fromArray(&allocator, &inputArray1, &inputShape1);
-//     defer inputTensor1.deinit();
+    var inputArray1: [2][4]u8 = [_][4]u8{
+        [_]u8{ 10, 20, 30, 40 },
+        [_]u8{ 50, 60, 70, 80 },
+    };
+    var inputShape1: [2]usize = [_]usize{ 2, 4 };
+    var inputTensor1 = try Tensor(u8).fromArray(&allocator, &inputArray1, &inputShape1);
+    defer inputTensor1.deinit();
 
-//     var indicesArray1: [2][2]usize = [_][2]usize{
-//         [_]usize{ 1, 3 },
-//         [_]usize{ 0, 2 },
-//     };
-//     var indicesShape1: [2]usize = [_]usize{ 2, 2 };
-//     var indicesTensor1 = try Tensor(usize).fromArray(&allocator, &indicesArray1, &indicesShape1);
-//     defer indicesTensor1.deinit();
+    var indicesArray1: [2][2]usize = [_][2]usize{
+        [_]usize{ 1, 3 },
+        [_]usize{ 0, 2 },
+    };
+    var indicesShape1: [2]usize = [_]usize{ 2, 2 };
+    var indicesTensor1 = try Tensor(usize).fromArray(&allocator, &indicesArray1, &indicesShape1);
+    defer indicesTensor1.deinit();
 
-//     // Perform gather along axis 1
-//     var gatheredTensor1 = try TensMath.gather(u8, &inputTensor1, &indicesTensor1, 1);
-//     defer gatheredTensor1.deinit();
+    // Perform gather along axis 1
+    var gatheredTensor1 = try TensMath.gather(u8, &inputTensor1, &indicesTensor1, 1);
+    defer gatheredTensor1.deinit();
 
-//     // Expected output tensor: [
-//     //   [20, 40],
-//     //   [10, 30],
-//     //   [60, 80],
-//     //   [50, 70]
-//     // ], shape [2, 2, 2]
-//     const expectedData1: [8]u8 = [_]u8{ 20, 40, 10, 30, 60, 80, 50, 70 };
-//     const expectedShape1: [3]usize = [_]usize{ 2, 2, 2 };
+    // Expected output tensor: [
+    //   [20, 40],
+    //   [10, 30],
+    //   [60, 80],
+    //   [50, 70]
+    // ], shape [2, 2, 2]
+    const expectedData1: [8]u8 = [_]u8{ 20, 40, 10, 30, 60, 80, 50, 70 };
+    const expectedShape1: [3]usize = [_]usize{ 2, 2, 2 };
 
-//     // Check shape
-//     try std.testing.expect(gatheredTensor1.shape.len == expectedShape1.len);
-//     for (0..expectedShape1.len) |i| {
-//         try std.testing.expect(gatheredTensor1.shape[i] == expectedShape1[i]);
-//     }
+    // Check shape
+    try std.testing.expect(gatheredTensor1.shape.len == expectedShape1.len);
+    for (0..expectedShape1.len) |i| {
+        try std.testing.expect(gatheredTensor1.shape[i] == expectedShape1[i]);
+    }
 
-//     // Check data
-//     tests_log.debug("\n     gatheredTensor1.size: {}\n", .{gatheredTensor1.size});
-//     gatheredTensor1.print();
+    // Check data
+    tests_log.debug("\n     gatheredTensor1.size: {}\n", .{gatheredTensor1.size});
+    gatheredTensor1.print();
 
-//     try std.testing.expect(gatheredTensor1.size == 8);
-//     for (0..gatheredTensor1.size) |i| {
-//         tests_log.debug("\n     gatheredTensor1.data[i]: {}\n", .{expectedData1[i]});
-//         tests_log.debug("\n     expectedData1[i]: {}\n", .{gatheredTensor1.data[i]});
-//         try std.testing.expect(gatheredTensor1.data[i] == expectedData1[i]);
-//     }
+    try std.testing.expect(gatheredTensor1.size == 8);
+    for (0..gatheredTensor1.size) |i| {
+        tests_log.debug("\n     gatheredTensor1.data[i]: {}\n", .{expectedData1[i]});
+        tests_log.debug("\n     expectedData1[i]: {}\n", .{gatheredTensor1.data[i]});
+        try std.testing.expect(gatheredTensor1.data[i] == expectedData1[i]);
+    }
 
-//     // -------------------------------------------------------------------------------------
-//     // Test Case 3: Error Handling - Invalid Axis
-//     // -------------------------------------------------------------------------------------
-//     tests_log.info("\n     test: gather with invalid axis", .{});
-//     const invalidAxis: usize = 3; // Input tensor has 2 dimensions
-//     const result0 = TensMath.gather(u8, &inputTensor0, &indicesTensor0, invalidAxis);
-//     try std.testing.expect(result0 == TensorError.InvalidAxis);
-// }
+    // -------------------------------------------------------------------------------------
+    // Test Case 3: Error Handling - Invalid Axis
+    // -------------------------------------------------------------------------------------
+    tests_log.info("\n     test: gather with invalid axis", .{});
+    const invalidAxis: usize = 3; // Input tensor has 2 dimensions
+    const result0 = TensMath.gather(u8, &inputTensor0, &indicesTensor0, invalidAxis);
+    try std.testing.expect(result0 == TensorError.InvalidAxis);
+}
 
-// test "gather - negative axis" {
-//     tests_log.info("\n     test: gather - negative axis", .{});
-//     const allocator = pkgAllocator.allocator;
+test "gather - negative axis" {
+    tests_log.info("\n     test: gather - negative axis", .{});
+    const allocator = pkgAllocator.allocator;
 
-//     // Initialize input tensor: 2x3 matrix
-//     var inputArray: [2][3]u8 = [_][3]u8{
-//         [_]u8{ 1, 2, 3 },
-//         [_]u8{ 4, 5, 6 },
-//     };
-//     var inputShape: [2]usize = [_]usize{ 2, 3 };
-//     var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
-//     defer inputTensor.deinit();
+    // Initialize input tensor: 2x3 matrix
+    var inputArray: [2][3]u8 = [_][3]u8{
+        [_]u8{ 1, 2, 3 },
+        [_]u8{ 4, 5, 6 },
+    };
+    var inputShape: [2]usize = [_]usize{ 2, 3 };
+    var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
+    defer inputTensor.deinit();
 
-//     // Initialize indices tensor: [1]
-//     var indicesArray: [1]usize = [_]usize{1};
-//     var indicesShape: [1]usize = [_]usize{1};
-//     var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
-//     defer indicesTensor.deinit();
+    // Initialize indices tensor: [1]
+    var indicesArray: [1]usize = [_]usize{1};
+    var indicesShape: [1]usize = [_]usize{1};
+    var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
+    defer indicesTensor.deinit();
 
-//     // Gather along axis -2 (equivalent to axis 0)
-//     var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, -2);
-//     defer gatheredTensor.deinit();
+    // Gather along axis -2 (equivalent to axis 0)
+    var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, -2);
+    defer gatheredTensor.deinit();
 
-//     // Expected: [4, 5, 6]
-//     try std.testing.expect(gatheredTensor.shape[0] == 1);
-//     try std.testing.expect(gatheredTensor.shape[1] == 3);
-//     try std.testing.expect(gatheredTensor.data[0] == 4);
-//     try std.testing.expect(gatheredTensor.data[1] == 5);
-//     try std.testing.expect(gatheredTensor.data[2] == 6);
-// }
+    // Expected: [4, 5, 6]
+    try std.testing.expect(gatheredTensor.shape[0] == 1);
+    try std.testing.expect(gatheredTensor.shape[1] == 3);
+    try std.testing.expect(gatheredTensor.data[0] == 4);
+    try std.testing.expect(gatheredTensor.data[1] == 5);
+    try std.testing.expect(gatheredTensor.data[2] == 6);
+}
 
-// test "gather - invalid indices" {
-//     tests_log.info("\n     test: gather - invalid indices", .{});
-//     const allocator = pkgAllocator.allocator;
+test "gather - invalid indices" {
+    tests_log.info("\n     test: gather - invalid indices", .{});
+    const allocator = pkgAllocator.allocator;
 
-//     // Initialize input tensor: 2x2 matrix
-//     var inputArray: [2][2]u8 = [_][2]u8{
-//         [_]u8{ 1, 2 },
-//         [_]u8{ 3, 4 },
-//     };
-//     var inputShape: [2]usize = [_]usize{ 2, 2 };
-//     var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
-//     defer inputTensor.deinit();
+    // Initialize input tensor: 2x2 matrix
+    var inputArray: [2][2]u8 = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+    };
+    var inputShape: [2]usize = [_]usize{ 2, 2 };
+    var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
+    defer inputTensor.deinit();
 
-//     // Initialize indices tensor with invalid index
-//     var indicesArray: [1]usize = [_]usize{2}; // Invalid index (only 0,1 are valid)
-//     var indicesShape: [1]usize = [_]usize{1};
-//     var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
-//     defer indicesTensor.deinit();
+    // Initialize indices tensor with invalid index
+    var indicesArray: [1]usize = [_]usize{2}; // Invalid index (only 0,1 are valid)
+    var indicesShape: [1]usize = [_]usize{1};
+    var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
+    defer indicesTensor.deinit();
 
-//     // Should return error for out of bounds index
-//     try std.testing.expectError(TensorError.IndexOutOfBounds, TensMath.gather(u8, &inputTensor, &indicesTensor, 0));
-// }
+    // Should return error for out of bounds index
+    try std.testing.expectError(TensorError.IndexOutOfBounds, TensMath.gather(u8, &inputTensor, &indicesTensor, 0));
+}
 
-// test "gather - multi-dimensional indices" {
-//     tests_log.info("\n     test: gather - multi-dimensional indices", .{});
-//     const allocator = pkgAllocator.allocator;
+test "gather - multi-dimensional indices" {
+    tests_log.info("\n     test: gather - multi-dimensional indices", .{});
+    const allocator = pkgAllocator.allocator;
 
-//     // Initialize input tensor: 3x3 matrix
-//     var inputArray: [3][3]u8 = [_][3]u8{
-//         [_]u8{ 1, 2, 3 },
-//         [_]u8{ 4, 5, 6 },
-//         [_]u8{ 7, 8, 9 },
-//     };
-//     var inputShape: [2]usize = [_]usize{ 3, 3 };
-//     var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
-//     defer inputTensor.deinit();
+    // Initialize input tensor: 3x3 matrix
+    var inputArray: [3][3]u8 = [_][3]u8{
+        [_]u8{ 1, 2, 3 },
+        [_]u8{ 4, 5, 6 },
+        [_]u8{ 7, 8, 9 },
+    };
+    var inputShape: [2]usize = [_]usize{ 3, 3 };
+    var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
+    defer inputTensor.deinit();
 
-//     // Initialize 2D indices tensor: [[0,2], [1,1]]
-//     var indicesArray: [2][2]usize = [_][2]usize{
-//         [_]usize{ 0, 2 },
-//         [_]usize{ 1, 1 },
-//     };
-//     var indicesShape: [2]usize = [_]usize{ 2, 2 };
-//     var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
-//     defer indicesTensor.deinit();
+    // Initialize 2D indices tensor: [[0,2], [1,1]]
+    var indicesArray: [2][2]usize = [_][2]usize{
+        [_]usize{ 0, 2 },
+        [_]usize{ 1, 1 },
+    };
+    var indicesShape: [2]usize = [_]usize{ 2, 2 };
+    var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
+    defer indicesTensor.deinit();
 
-//     // Gather along axis 0
-//     var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, 0);
-//     defer gatheredTensor.deinit();
+    // Gather along axis 0
+    var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, 0);
+    defer gatheredTensor.deinit();
 
-//     // Expected shape: [2, 2, 3]
-//     try std.testing.expect(gatheredTensor.shape[0] == 2);
-//     try std.testing.expect(gatheredTensor.shape[1] == 2);
-//     try std.testing.expect(gatheredTensor.shape[2] == 3);
+    // Expected shape: [2, 2, 3]
+    try std.testing.expect(gatheredTensor.shape[0] == 2);
+    try std.testing.expect(gatheredTensor.shape[1] == 2);
+    try std.testing.expect(gatheredTensor.shape[2] == 3);
 
-//     // Check first row (indices 0,2): [1,2,3], [7,8,9]
-//     try std.testing.expect(gatheredTensor.data[0] == 1);
-//     try std.testing.expect(gatheredTensor.data[1] == 2);
-//     try std.testing.expect(gatheredTensor.data[2] == 3);
-//     try std.testing.expect(gatheredTensor.data[3] == 7);
-//     try std.testing.expect(gatheredTensor.data[4] == 8);
-//     try std.testing.expect(gatheredTensor.data[5] == 9);
+    // Check first row (indices 0,2): [1,2,3], [7,8,9]
+    try std.testing.expect(gatheredTensor.data[0] == 1);
+    try std.testing.expect(gatheredTensor.data[1] == 2);
+    try std.testing.expect(gatheredTensor.data[2] == 3);
+    try std.testing.expect(gatheredTensor.data[3] == 7);
+    try std.testing.expect(gatheredTensor.data[4] == 8);
+    try std.testing.expect(gatheredTensor.data[5] == 9);
 
-//     // Check second row (indices 1,1): [4,5,6], [4,5,6]
-//     try std.testing.expect(gatheredTensor.data[6] == 4);
-//     try std.testing.expect(gatheredTensor.data[7] == 5);
-//     try std.testing.expect(gatheredTensor.data[8] == 6);
-//     try std.testing.expect(gatheredTensor.data[9] == 4);
-//     try std.testing.expect(gatheredTensor.data[10] == 5);
-//     try std.testing.expect(gatheredTensor.data[11] == 6);
-// }
+    // Check second row (indices 1,1): [4,5,6], [4,5,6]
+    try std.testing.expect(gatheredTensor.data[6] == 4);
+    try std.testing.expect(gatheredTensor.data[7] == 5);
+    try std.testing.expect(gatheredTensor.data[8] == 6);
+    try std.testing.expect(gatheredTensor.data[9] == 4);
+    try std.testing.expect(gatheredTensor.data[10] == 5);
+    try std.testing.expect(gatheredTensor.data[11] == 6);
+}
 
-// test "gather - single element tensor" {
-//     tests_log.info("\n     test: gather - single element tensor", .{});
-//     const allocator = pkgAllocator.allocator;
+test "gather - single element tensor" {
+    tests_log.info("\n     test: gather - single element tensor", .{});
+    const allocator = pkgAllocator.allocator;
 
-//     // Initialize input tensor: [[[1]]]
-//     var inputArray: [1][1][1]u8 = [_][1][1]u8{[_][1]u8{[_]u8{1}}};
-//     var inputShape: [3]usize = [_]usize{ 1, 1, 1 };
-//     var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
-//     defer inputTensor.deinit();
+    // Initialize input tensor: [[[1]]]
+    var inputArray: [1][1][1]u8 = [_][1][1]u8{[_][1]u8{[_]u8{1}}};
+    var inputShape: [3]usize = [_]usize{ 1, 1, 1 };
+    var inputTensor = try Tensor(u8).fromArray(&allocator, &inputArray, &inputShape);
+    defer inputTensor.deinit();
 
-//     // Initialize indices tensor: [0]
-//     var indicesArray: [1]usize = [_]usize{0};
-//     var indicesShape: [1]usize = [_]usize{1};
-//     var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
-//     defer indicesTensor.deinit();
+    // Initialize indices tensor: [0]
+    var indicesArray: [1]usize = [_]usize{0};
+    var indicesShape: [1]usize = [_]usize{1};
+    var indicesTensor = try Tensor(usize).fromArray(&allocator, &indicesArray, &indicesShape);
+    defer indicesTensor.deinit();
 
-//     // Test gathering on each axis
-//     inline for (0..3) |axis| {
-//         var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, axis);
-//         defer gatheredTensor.deinit();
+    // Test gathering on each axis
+    inline for (0..3) |axis| {
+        var gatheredTensor = try TensMath.gather(u8, &inputTensor, &indicesTensor, axis);
+        defer gatheredTensor.deinit();
 
-//         try std.testing.expect(gatheredTensor.data[0] == 1);
-//         try std.testing.expect(gatheredTensor.size == 1);
-//     }
-// }
+        try std.testing.expect(gatheredTensor.data[0] == 1);
+        try std.testing.expect(gatheredTensor.size == 1);
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_op_gelu 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_gelu 2.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const zant = @import("zant");
+
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorError = zant.utils.error_handler.TensorError;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+
+const tests_log = std.log.scoped(.lib_elementWise);
+
+test "test gelu with approximate = none and valid f32 tensor" {
+    const allocator = std.testing.allocator;
+
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 0.0, 1.0, -1.0 },
+        [_]f32{ 0.5, -0.5, 2.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 3 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    var result = try TensMath.gelu(f32, &tensor, "none");
+    defer result.deinit();
+
+    const expected_values = [_]f32{
+        0.0000000000000000,
+        0.8413447460685429,
+        -0.15865525393145707,
+        0.34573123063700656,
+        -0.15426876936299344,
+        1.9544997361036416,
+    };
+
+    const epsilon: f32 = 1e-6;
+    for (0..result.size) |i| {
+        try std.testing.expect(std.math.approxEqAbs(f32, result.data[i], expected_values[i], epsilon));
+    }
+}
+
+test "test gelu with approximate = tanh and valid f32 tensor" {
+    const allocator = std.testing.allocator;
+
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 0.0, 1.0, -1.0 },
+        [_]f32{ 0.5, -0.5, 2.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 3 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    var result = try TensMath.gelu(f32, &tensor, "tanh");
+    defer result.deinit();
+
+    const expected_values = [_]f32{
+        0.00000000, // GELU(0.0) = 0.5 * 0 * (1 + tanh(...)) = 0
+        0.8411919906082768, // GELU(1.0) ≈ 0.84119225
+        -0.15880800939172324, // GELU(-1.0) ≈ -0.15880775
+        0.34571400982514394, // GELU(0.5) ≈ 0.34567261
+        -0.15428599017485606, // GELU(-0.5) ≈ -0.15432739
+        1.954597694087775, // GELU(2.0) ≈ 1.95450306
+    };
+
+    const epsilon: f32 = 1e-5;
+    for (0..result.size) |i| {
+        try std.testing.expect(std.math.approxEqAbs(f32, result.data[i], expected_values[i], epsilon));
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_op_min.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_min.zig
@@ -1,0 +1,424 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+
+const tests_log = std.log.scoped(.test_min);
+
+// ---------------------------------------------------------------
+// -------------------- TESTS FOR MIN OPERATOR -------------------
+// ---------------------------------------------------------------
+
+// Test basic two-tensor min operation
+test "Min - basic two tensors" {
+    tests_log.info("\n     test: Min - basic two tensors\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [3]usize = [_]usize{ 2, 2, 2 };
+    var dataA: [8]f32 = [_]f32{ 1.0, 5.0, 3.0, 7.0, 2.0, 6.0, 4.0, 8.0 };
+    var dataB: [8]f32 = [_]f32{ 2.0, 4.0, 6.0, 1.0, 3.0, 5.0, 7.0, 2.0 };
+    const expected: [8]f32 = [_]f32{ 1.0, 4.0, 3.0, 1.0, 2.0, 5.0, 4.0, 2.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("Basic two-tensor min test passed\n", .{});
+}
+
+// Test min with multiple tensors (3 tensors)
+test "Min - multiple tensors (3)" {
+    tests_log.info("\n     test: Min - multiple tensors (3)\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [2]usize = [_]usize{ 2, 3 };
+    var dataA: [6]f32 = [_]f32{ 5.0, 3.0, 8.0, 2.0, 7.0, 4.0 };
+    var dataB: [6]f32 = [_]f32{ 4.0, 6.0, 2.0, 9.0, 1.0, 5.0 };
+    var dataC: [6]f32 = [_]f32{ 3.0, 5.0, 7.0, 1.0, 6.0, 3.0 };
+    const expected: [6]f32 = [_]f32{ 3.0, 3.0, 2.0, 1.0, 1.0, 3.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+    var tensorC = try Tensor(f32).fromArray(&allocator, &dataC, &shape);
+    defer tensorC.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    var inputs = [_]*Tensor(f32){ &tensorA, &tensorB, &tensorC };
+    try TensMath.min_lean(f32, &inputs, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("Multiple tensors min test passed\n", .{});
+}
+
+// Test min with all positive values
+test "Min - all positive values" {
+    tests_log.info("\n     test: Min - all positive values\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{5};
+    var dataA: [5]f32 = [_]f32{ 10.0, 20.0, 5.0, 15.0, 8.0 };
+    var dataB: [5]f32 = [_]f32{ 12.0, 18.0, 6.0, 14.0, 9.0 };
+    const expected: [5]f32 = [_]f32{ 10.0, 18.0, 5.0, 14.0, 8.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("All positive values min test passed\n", .{});
+}
+
+// Test min with all negative values
+test "Min - all negative values" {
+    tests_log.info("\n     test: Min - all negative values\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{4};
+    var dataA: [4]f32 = [_]f32{ -5.0, -2.0, -8.0, -3.0 };
+    var dataB: [4]f32 = [_]f32{ -6.0, -1.0, -7.0, -4.0 };
+    const expected: [4]f32 = [_]f32{ -6.0, -2.0, -8.0, -4.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("All negative values min test passed\n", .{});
+}
+
+// Test min with mixed positive and negative values
+test "Min - mixed positive and negative" {
+    tests_log.info("\n     test: Min - mixed positive and negative\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{6};
+    var dataA: [6]f32 = [_]f32{ -5.0, 3.0, -2.0, 7.0, 0.0, -1.0 };
+    var dataB: [6]f32 = [_]f32{ -3.0, 5.0, -4.0, 2.0, 1.0, -2.0 };
+    const expected: [6]f32 = [_]f32{ -5.0, 3.0, -4.0, 2.0, 0.0, -2.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("Mixed positive and negative min test passed\n", .{});
+}
+
+// Test min with zeros
+test "Min - with zero values" {
+    tests_log.info("\n     test: Min - with zero values\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{5};
+    var dataA: [5]f32 = [_]f32{ 0.0, 5.0, 0.0, -3.0, 2.0 };
+    var dataB: [5]f32 = [_]f32{ 1.0, 0.0, -1.0, 0.0, 0.0 };
+    const expected: [5]f32 = [_]f32{ 0.0, 0.0, -1.0, -3.0, 0.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("Min with zero values test passed\n", .{});
+}
+
+// Test min with identical tensors
+test "Min - identical tensors" {
+    tests_log.info("\n     test: Min - identical tensors\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [2]usize = [_]usize{ 2, 3 };
+    var data: [6]f32 = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &data, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &data, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(data[i], val, 1e-6);
+    }
+
+    tests_log.info("Identical tensors min test passed\n", .{});
+}
+
+// Test reduce_min (global minimum)
+test "Min - reduce_min global" {
+    tests_log.info("\n     test: Min - reduce_min global\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [3]usize = [_]usize{ 2, 2, 2 };
+    var data: [8]f32 = [_]f32{ 5.0, 3.0, 8.0, -2.0, 7.0, 4.0, 1.0, 6.0 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &data, &shape);
+    defer tensor.deinit();
+
+    var result = try TensMath.reduce_min(f32, &tensor, null, false);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), result.size);
+    try std.testing.expectApproxEqAbs(-2.0, result.data[0], 1e-6);
+
+    tests_log.info("Global reduce_min test passed\n", .{});
+}
+
+// Test reduce_min with keepdims=true
+test "Min - reduce_min with keepdims" {
+    tests_log.info("\n     test: Min - reduce_min with keepdims\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [2]usize = [_]usize{ 3, 2 };
+    var data: [6]f32 = [_]f32{ 5.0, -1.0, 3.0, 7.0, 2.0, 4.0 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &data, &shape);
+    defer tensor.deinit();
+
+    var result = try TensMath.reduce_min(f32, &tensor, null, true);
+    defer result.deinit();
+
+    // With keepdims, shape should be [1, 1]
+    try std.testing.expectEqual(@as(usize, 2), result.shape.len);
+    try std.testing.expectEqual(@as(usize, 1), result.shape[0]);
+    try std.testing.expectEqual(@as(usize, 1), result.shape[1]);
+    try std.testing.expectApproxEqAbs(-1.0, result.data[0], 1e-6);
+
+    tests_log.info("Reduce_min with keepdims test passed\n", .{});
+}
+
+// Test min with single element tensors
+test "Min - single element tensors" {
+    tests_log.info("\n     test: Min - single element tensors\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{1};
+    var dataA: [1]f32 = [_]f32{5.0};
+    var dataB: [1]f32 = [_]f32{3.0};
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    try std.testing.expectApproxEqAbs(3.0, output.data[0], 1e-6);
+
+    tests_log.info("Single element tensors min test passed\n", .{});
+}
+
+// Test min with integer type
+test "Min - integer type (i32)" {
+    tests_log.info("\n     test: Min - integer type (i32)\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{5};
+    var dataA: [5]i32 = [_]i32{ 10, -5, 3, 7, -2 };
+    var dataB: [5]i32 = [_]i32{ 8, -3, 5, 2, -4 };
+    const expected: [5]i32 = [_]i32{ 8, -5, 3, 2, -4 };
+
+    var tensorA = try Tensor(i32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(i32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(i32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(i32, &tensorA, &tensorB, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectEqual(expected[i], val);
+    }
+
+    tests_log.info("Integer type min test passed\n", .{});
+}
+
+// Test min with large tensors
+test "Min - large tensors" {
+    tests_log.info("\n     test: Min - large tensors\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    const size = 1000;
+    var shape: [1]usize = [_]usize{size};
+
+    var tensorA = try Tensor(f32).fromShape(&allocator, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromShape(&allocator, &shape);
+    defer tensorB.deinit();
+
+    // Fill with predictable values
+    for (0..size) |i| {
+        tensorA.data[i] = @as(f32, @floatFromInt(i));
+        tensorB.data[i] = @as(f32, @floatFromInt(size - i));
+    }
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    // Verify min is correctly computed
+    for (0..size) |i| {
+        const expected = @min(tensorA.data[i], tensorB.data[i]);
+        try std.testing.expectApproxEqAbs(expected, output.data[i], 1e-6);
+    }
+
+    tests_log.info("Large tensors min test passed\n", .{});
+}
+
+// Test min with 4+ tensors
+test "Min - four tensors" {
+    tests_log.info("\n     test: Min - four tensors\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{4};
+    var dataA: [4]f32 = [_]f32{ 5.0, 2.0, 8.0, 3.0 };
+    var dataB: [4]f32 = [_]f32{ 4.0, 6.0, 1.0, 9.0 };
+    var dataC: [4]f32 = [_]f32{ 3.0, 5.0, 7.0, 2.0 };
+    var dataD: [4]f32 = [_]f32{ 6.0, 1.0, 4.0, 8.0 };
+    const expected: [4]f32 = [_]f32{ 3.0, 1.0, 1.0, 2.0 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+    var tensorC = try Tensor(f32).fromArray(&allocator, &dataC, &shape);
+    defer tensorC.deinit();
+    var tensorD = try Tensor(f32).fromArray(&allocator, &dataD, &shape);
+    defer tensorD.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    var inputs = [_]*Tensor(f32){ &tensorA, &tensorB, &tensorC, &tensorD };
+    try TensMath.min_lean(f32, &inputs, &output);
+
+    for (output.data, 0..) |val, i| {
+        try std.testing.expectApproxEqAbs(expected[i], val, 1e-6);
+    }
+
+    tests_log.info("Four tensors min test passed\n", .{});
+}
+
+// Test get_min_output_shape
+test "Min - get_min_output_shape" {
+    tests_log.info("\n     test: Min - get_min_output_shape\n", .{});
+
+    var shape1: [2]usize = [_]usize{ 3, 4 };
+    var shape2: [2]usize = [_]usize{ 3, 4 };
+
+    const input_shapes = [_][]const usize{ &shape1, &shape2 };
+    const output_shape = try TensMath.get_min_output_shape(&input_shapes);
+    defer pkgAllocator.allocator.free(output_shape);
+
+    try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+    try std.testing.expectEqual(@as(usize, 3), output_shape[0]);
+    try std.testing.expectEqual(@as(usize, 4), output_shape[1]);
+
+    tests_log.info("get_min_output_shape test passed\n", .{});
+}
+
+// Test min with extreme values (infinity, very large/small numbers)
+test "Min - extreme values" {
+    tests_log.info("\n     test: Min - extreme values\n", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [1]usize = [_]usize{4};
+    var dataA: [4]f32 = [_]f32{ std.math.inf(f32), -std.math.inf(f32), 1e20, -1e20 };
+    var dataB: [4]f32 = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
+    const expected: [4]f32 = [_]f32{ 1.0, -std.math.inf(f32), 1.0, -1e20 };
+
+    var tensorA = try Tensor(f32).fromArray(&allocator, &dataA, &shape);
+    defer tensorA.deinit();
+    var tensorB = try Tensor(f32).fromArray(&allocator, &dataB, &shape);
+    defer tensorB.deinit();
+
+    var output = try Tensor(f32).fromShape(&allocator, &shape);
+    defer output.deinit();
+
+    try TensMath.min_two_lean(f32, &tensorA, &tensorB, &output);
+
+    try std.testing.expectApproxEqAbs(expected[0], output.data[0], 1e-6);
+    try std.testing.expect(std.math.isNegativeInf(output.data[1]));
+    try std.testing.expectApproxEqAbs(expected[2], output.data[2], 1e-6);
+    try std.testing.expectApproxEqAbs(expected[3], output.data[3], 1e10);
+
+    tests_log.info("Extreme values min test passed\n", .{});
+}

--- a/tests/Core/Tensor/TensorMath/test_op_pad 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_pad 2.zig
@@ -1,0 +1,326 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "get_pads_output_shape - basic" {
+    tests_log.info("\n     test: get_pads_output_shape - basic", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape = [_]usize{ 3, 4 };
+    var pads = [_]i64{ 1, 1, 2, 2 }; // [x1_begin, x2_begin, x1_end, x2_end]
+
+    const output_shape = try TensMath.get_pads_output_shape(allocator, &input_shape, &pads, null);
+    defer allocator.free(output_shape);
+
+    try std.testing.expectEqual(@as(usize, 2), output_shape.len);
+    try std.testing.expectEqual(@as(usize, 3 + 1 + 2), output_shape[0]); // 3 + pad_start[0] + pad_end[0]
+    try std.testing.expectEqual(@as(usize, 4 + 1 + 2), output_shape[1]); // 4 + pad_start[1] + pad_end[1]
+}
+
+test "get_pads_output_shape - with axes" {
+    tests_log.info("\n     test: get_pads_output_shape - with axes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape = [_]usize{ 3, 4, 5 };
+    var pads = [_]i64{ 1, 2, 3, 4 }; // pads for axes 0 and 2: [p0_start, p2_start, p0_end, p2_end]
+    var axes = [_]isize{ 0, 2 };
+
+    const output_shape = try TensMath.get_pads_output_shape(allocator, &input_shape, &pads, &axes);
+    defer allocator.free(output_shape);
+
+    try std.testing.expectEqual(@as(usize, 3), output_shape.len);
+    try std.testing.expectEqual(@as(usize, 3 + 1 + 3), output_shape[0]); // Axis 0 padded
+    try std.testing.expectEqual(@as(usize, 4), output_shape[1]); // Axis 1 not padded
+    try std.testing.expectEqual(@as(usize, 5 + 2 + 4), output_shape[2]); // Axis 2 padded
+}
+
+test "get_pads_output_shape - negative axes" {
+    tests_log.info("\n     test: get_pads_output_shape - negative axes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var input_shape = [_]usize{ 3, 4, 5 };
+    var pads = [_]i64{ 1, 2 }; // pads for axis -1 (axis 2): [p2_start, p2_end]
+    var axes = [_]isize{-1};
+
+    const output_shape = try TensMath.get_pads_output_shape(allocator, &input_shape, &pads, &axes);
+    defer allocator.free(output_shape);
+
+    try std.testing.expectEqual(@as(usize, 3), output_shape.len);
+    try std.testing.expectEqual(@as(usize, 3), output_shape[0]); // Axis 0 not padded
+    try std.testing.expectEqual(@as(usize, 4), output_shape[1]); // Axis 1 not padded
+    try std.testing.expectEqual(@as(usize, 5 + 1 + 2), output_shape[2]); // Axis 2 padded
+}
+
+test "get_pads_output_shape - error cases" {
+    tests_log.info("\n     test: get_pads_output_shape - error cases", .{});
+    const allocator = pkgAllocator.allocator;
+    var input_shape = [_]usize{ 3, 4 };
+
+    // Invalid pads length (should be rank * 2)
+    var invalid_pads = [_]i64{ 1, 1, 2 };
+    try std.testing.expectError(TensorMathError.InvalidPaddingShape, TensMath.get_pads_output_shape(allocator, &input_shape, &invalid_pads, null));
+
+    // Invalid axes length (pads length must be axes.len * 2)
+    var pads = [_]i64{ 1, 2 };
+    var invalid_axes = [_]isize{ 0, 1 }; // axes.len = 2, but pads.len = 2 != 2*2
+    try std.testing.expectError(TensorMathError.InvalidPaddingShape, TensMath.get_pads_output_shape(allocator, &input_shape, &pads, &invalid_axes));
+
+    // Repeated axes
+    var pads_rep = [_]i64{ 1, 1, 2, 2 };
+    var repeated_axes = [_]isize{ 0, 0 };
+    try std.testing.expectError(TensorMathError.InvalidInput, TensMath.get_pads_output_shape(allocator, &input_shape, &pads_rep, &repeated_axes));
+
+    // Axis out of range
+    var pads_oor = [_]i64{ 1, 2 };
+    var oor_axes = [_]isize{2}; // axis 2 is out of range for rank 2
+    try std.testing.expectError(TensorMathError.AxisOutOfRange, TensMath.get_pads_output_shape(allocator, &input_shape, &pads_oor, &oor_axes));
+
+    // Padding results in non-positive dimension
+    var neg_pads = [_]i64{ -2, -2, -2, -2 };
+    try std.testing.expectError(TensorMathError.InvalidPaddingSize, TensMath.get_pads_output_shape(allocator, &input_shape, &neg_pads, null));
+}
+
+// --- Pad Tests --- //
+
+// Helper to compare tensors for pad tests
+fn expectTensorEqual(comptime T: type, expected: *const Tensor(T), actual: *const Tensor(T)) !void {
+    try std.testing.expectEqual(expected.shape.len, actual.shape.len);
+    for (expected.shape, 0..) |dim, i| {
+        try std.testing.expectEqual(dim, actual.shape[i]);
+    }
+    try std.testing.expectEqual(expected.size, actual.size);
+    for (expected.data, 0..) |val, i| {
+        if (@TypeOf(T) == f32 or @TypeOf(T) == f64) {
+            try std.testing.expectApproxEqAbs(val, actual.data[i], 1e-6);
+        } else {
+            try std.testing.expectEqual(val, actual.data[i]);
+        }
+    }
+}
+
+// Test Case 1: Constant Mode (like ONNX Example 1)
+test "pads constant mode basic 2D" {
+    tests_log.info("\n     test: pads constant mode basic 2D", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_][2]f32{
+        [_]f32{ 1.0, 1.2 },
+        [_]f32{ 2.3, 3.4 },
+        [_]f32{ 4.5, 5.7 },
+    };
+    var data_shape = [_]usize{ 3, 2 };
+    var data_tensor = try Tensor(f32).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    var pads_array = [_]i64{ 0, 2, 0, 0 }; // pads = [x0_begin, x1_begin, x0_end, x1_end]
+    var pads_shape = [_]usize{4};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var output = try TensMath.pads(f32, &data_tensor, &pads_tensor, "constant", @as(f32, 0.0), null);
+    defer output.deinit();
+
+    var expected_array = [_][4]f32{
+        [_]f32{ 0.0, 0.0, 1.0, 1.2 },
+        [_]f32{ 0.0, 0.0, 2.3, 3.4 },
+        [_]f32{ 0.0, 0.0, 4.5, 5.7 },
+    };
+    var expected_shape = [_]usize{ 3, 4 };
+    var expected_tensor = try Tensor(f32).fromArray(&allocator, &expected_array, &expected_shape);
+    defer expected_tensor.deinit();
+
+    try expectTensorEqual(f32, &expected_tensor, &output);
+}
+
+// Test Case 2: Constant Mode with specific value and axes
+test "pads constant mode with value and axes" {
+    tests_log.info("\n     test: pads constant mode with value and axes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_]i32{ 1, 2, 3 };
+    var data_shape = [_]usize{3};
+    var data_tensor = try Tensor(i32).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    var pads_array = [_]i64{ 2, 1 }; // pads for axis 0: [p0_start, p0_end]
+    var pads_shape = [_]usize{2};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var axes_array = [_]isize{0};
+    var axes_shape = [_]usize{1};
+    var axes_tensor = try Tensor(isize).fromArray(&allocator, &axes_array, &axes_shape);
+    defer axes_tensor.deinit();
+
+    var output = try TensMath.pads(i32, &data_tensor, &pads_tensor, "constant", @as(i32, -5), &axes_tensor);
+    defer output.deinit();
+
+    var expected_array = [_]i32{ -5, -5, 1, 2, 3, -5 };
+    var expected_shape = [_]usize{6};
+    var expected_tensor = try Tensor(i32).fromArray(&allocator, &expected_array, &expected_shape);
+    defer expected_tensor.deinit();
+
+    try expectTensorEqual(i32, &expected_tensor, &output);
+}
+
+// Test Case 4: Edge Mode (like ONNX Example 3)
+test "pads edge mode basic 2D" {
+    tests_log.info("\n     test: pads edge mode basic 2D", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_][2]f32{
+        [_]f32{ 1.0, 1.2 },
+        [_]f32{ 2.3, 3.4 },
+        [_]f32{ 4.5, 5.7 },
+    };
+    var data_shape = [_]usize{ 3, 2 };
+    var data_tensor = try Tensor(f32).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    var pads_array = [_]i64{ 0, 2, 0, 0 }; // pads = [x0_begin, x1_begin, x0_end, x1_end]
+    var pads_shape = [_]usize{4};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var output = try TensMath.pads(f32, &data_tensor, &pads_tensor, "edge", null, null);
+    defer output.deinit();
+
+    var expected_array = [_][4]f32{
+        [_]f32{ 1.0, 1.0, 1.0, 1.2 }, // Prepend edge value 1.0 twice
+        [_]f32{ 2.3, 2.3, 2.3, 3.4 }, // Prepend edge value 2.3 twice
+        [_]f32{ 4.5, 4.5, 4.5, 5.7 }, // Prepend edge value 4.5 twice
+    };
+    var expected_shape = [_]usize{ 3, 4 };
+    var expected_tensor = try Tensor(f32).fromArray(&allocator, &expected_array, &expected_shape);
+    defer expected_tensor.deinit();
+
+    try expectTensorEqual(f32, &expected_tensor, &output);
+}
+
+// Test Case 5: Wrap Mode (like ONNX Example 4)
+test "pads wrap mode basic 2D" {
+    tests_log.info("\n     test: pads wrap mode basic 2D", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_][2]f32{
+        [_]f32{ 1.0, 1.2 }, // Row 0
+        [_]f32{ 2.3, 3.4 }, // Row 1
+        [_]f32{ 4.5, 5.7 }, // Row 2
+    };
+    var data_shape = [_]usize{ 3, 2 };
+    var data_tensor = try Tensor(f32).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    // Pads: [pad_start_0, pad_start_1, pad_end_0, pad_end_1]
+    var pads_array = [_]i64{ 1, 1, 1, 2 }; // Pad row 0: 1 start, 1 end; Pad row 1: 1 start, 2 end
+    var pads_shape = [_]usize{4};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var output = try TensMath.pads(f32, &data_tensor, &pads_tensor, "wrap", null, null);
+    defer output.deinit();
+
+    // Expected Output Shape: [3 + 1 + 1, 2 + 1 + 2] = [5, 5]
+    // Row padding wraps rows: prepend row 2, append row 0
+    // Col padding wraps cols: prepend col 1, append cols 0, 1
+
+    // Expected Data (5x5):
+    // Row -1 (wrap row 2): [4.5, 5.7] -> Col padded: [5.7, 4.5, 5.7, 4.5, 5.7]
+    // Row 0 (data row 0):  [1.0, 1.2] -> Col padded: [1.2, 1.0, 1.2, 1.0, 1.2]
+    // Row 1 (data row 1):  [2.3, 3.4] -> Col padded: [3.4, 2.3, 3.4, 2.3, 3.4]
+    // Row 2 (data row 2):  [4.5, 5.7] -> Col padded: [5.7, 4.5, 5.7, 4.5, 5.7]
+    // Row 3 (wrap row 0):  [1.0, 1.2] -> Col padded: [1.2, 1.0, 1.2, 1.0, 1.2]
+    var expected_array = [_][5]f32{
+        [_]f32{ 5.7, 4.5, 5.7, 4.5, 5.7 }, // Wrapped row 2, cols wrapped
+        [_]f32{ 1.2, 1.0, 1.2, 1.0, 1.2 }, // Data row 0, cols wrapped
+        [_]f32{ 3.4, 2.3, 3.4, 2.3, 3.4 }, // Data row 1, cols wrapped
+        [_]f32{ 5.7, 4.5, 5.7, 4.5, 5.7 }, // Data row 2, cols wrapped
+        [_]f32{ 1.2, 1.0, 1.2, 1.0, 1.2 }, // Wrapped row 0, cols wrapped
+    };
+    var expected_shape = [_]usize{ 5, 5 };
+    var expected_tensor = try Tensor(f32).fromArray(&allocator, &expected_array, &expected_shape);
+    defer expected_tensor.deinit();
+
+    try expectTensorEqual(f32, &expected_tensor, &output);
+}
+
+// Test Case 6: Padding a 3D tensor with constant mode
+test "pads constant mode 3D" {
+    tests_log.info("\n     test: pads constant mode 3D", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_][2][2]u8{
+        [_][2]u8{
+            [_]u8{ 1, 2 },
+            [_]u8{ 3, 4 },
+        },
+        [_][2]u8{
+            [_]u8{ 5, 6 },
+            [_]u8{ 7, 8 },
+        },
+    };
+    var data_shape = [_]usize{ 2, 2, 2 };
+    var data_tensor = try Tensor(u8).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    // Pad 1 element start/end on axis 1, 1 element start on axis 2
+    // pads = [p0s, p1s, p2s, p0e, p1e, p2e]
+    var pads_array = [_]i64{ 0, 1, 1, 0, 1, 0 };
+    var pads_shape = [_]usize{6};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var output = try TensMath.pads(u8, &data_tensor, &pads_tensor, "constant", @as(u8, 99), null);
+    defer output.deinit();
+
+    // Expected shape: [2, 2+1+1, 2+1+0] = [2, 4, 3]
+    var expected_array = [_][4][3]u8{
+        [_][3]u8{ // Batch 0
+            [_]u8{ 99, 99, 99 }, // Padded row
+            [_]u8{ 99, 1, 2 }, // Original [1, 2] with pad start
+            [_]u8{ 99, 3, 4 }, // Original [3, 4] with pad start
+            [_]u8{ 99, 99, 99 }, // Padded row
+        },
+        [_][3]u8{ // Batch 1
+            [_]u8{ 99, 99, 99 }, // Padded row
+            [_]u8{ 99, 5, 6 }, // Original [5, 6] with pad start
+            [_]u8{ 99, 7, 8 }, // Original [7, 8] with pad start
+            [_]u8{ 99, 99, 99 }, // Padded row
+        },
+    };
+    var expected_shape = [_]usize{ 2, 4, 3 };
+    var expected_tensor = try Tensor(u8).fromArray(&allocator, &expected_array, &expected_shape);
+    defer expected_tensor.deinit();
+
+    try expectTensorEqual(u8, &expected_tensor, &output);
+}
+
+// Test Case 7: Zero padding (should be identity)
+test "pads zero padding" {
+    tests_log.info("\n     test: pads zero padding", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var data_array = [_][2]f32{
+        [_]f32{ 1.0, 1.2 },
+        [_]f32{ 2.3, 3.4 },
+    };
+    var data_shape = [_]usize{ 2, 2 };
+    var data_tensor = try Tensor(f32).fromArray(&allocator, &data_array, &data_shape);
+    defer data_tensor.deinit();
+
+    var pads_array = [_]i64{ 0, 0, 0, 0 }; // No padding
+    var pads_shape = [_]usize{4};
+    var pads_tensor = try Tensor(i64).fromArray(&allocator, &pads_array, &pads_shape);
+    defer pads_tensor.deinit();
+
+    var output = try TensMath.pads(f32, &data_tensor, &pads_tensor, "constant", @as(f32, 99.0), null);
+    defer output.deinit();
+
+    // Expected should be the same as input
+    try expectTensorEqual(f32, &data_tensor, &output);
+}

--- a/tests/Core/Tensor/TensorMath/test_op_resize 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_resize 2.zig
@@ -1,0 +1,197 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+const TensorError = zant.utils.error_handler.TensorError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "get_resize_output_shape()" {
+    tests_log.info("\n     test: get_resize_output_shape \n", .{});
+
+    var input_shape = [_]usize{ 2, 3, 4 };
+    var scales = [_]f32{ 2.0, 1.5, 0.5 };
+    var target_sizes = [_]usize{ 4, 4, 2 };
+
+    // Test with scales
+    {
+        const output_shape = try TensMath.get_resize_output_shape(&input_shape, &scales, null);
+        defer pkgAllocator.allocator.free(output_shape);
+        try std.testing.expectEqual(@as(usize, 4), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 4), output_shape[1]);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[2]);
+    }
+
+    // Test with target sizes
+    {
+        const output_shape = try TensMath.get_resize_output_shape(&input_shape, null, &target_sizes);
+        defer pkgAllocator.allocator.free(output_shape);
+        try std.testing.expectEqual(@as(usize, 4), output_shape[0]);
+        try std.testing.expectEqual(@as(usize, 4), output_shape[1]);
+        try std.testing.expectEqual(@as(usize, 2), output_shape[2]);
+    }
+
+    // Test invalid input (both scales and sizes null)
+    try std.testing.expectError(TensorError.InvalidInput, TensMath.get_resize_output_shape(&input_shape, null, null));
+
+    // Test invalid input (both scales and sizes provided)
+    try std.testing.expectError(TensorError.InvalidInput, TensMath.get_resize_output_shape(&input_shape, &scales, &target_sizes));
+
+    // Test mismatched dimensions
+    var wrong_scales = [_]f32{ 2.0, 1.5 };
+    try std.testing.expectError(TensorError.InvalidInput, TensMath.get_resize_output_shape(&input_shape, &wrong_scales, null));
+
+    var wrong_sizes = [_]usize{ 4, 4 };
+    try std.testing.expectError(TensorError.InvalidInput, TensMath.get_resize_output_shape(&input_shape, null, &wrong_sizes));
+}
+
+test "resize with nearest neighbor interpolation" {
+    tests_log.info("\n     test: resize with nearest neighbor interpolation", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Test 1D tensor resize
+    var input_array_1d = [_]u8{ 1, 2, 3, 4 };
+    var shape_1d = [_]usize{4};
+    var tensor_1d = try Tensor(u8).fromArray(&allocator, &input_array_1d, &shape_1d);
+    defer tensor_1d.deinit();
+
+    // Scale up by 2x
+    var scales = [_]f32{2.0};
+    var resized_1d = try TensMath.resize(u8, &tensor_1d, "nearest", &scales, null, "half_pixel");
+    defer resized_1d.deinit();
+
+    try std.testing.expectEqual(@as(usize, 8), resized_1d.size);
+    try std.testing.expectEqual(@as(u8, 1), resized_1d.data[0]);
+    try std.testing.expectEqual(@as(u8, 1), resized_1d.data[1]);
+    try std.testing.expectEqual(@as(u8, 2), resized_1d.data[2]);
+    try std.testing.expectEqual(@as(u8, 2), resized_1d.data[3]);
+
+    // Test 2D tensor resize
+    var input_array_2d = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+    };
+    var shape_2d = [_]usize{ 2, 2 };
+    var tensor_2d = try Tensor(u8).fromArray(&allocator, &input_array_2d, &shape_2d);
+    defer tensor_2d.deinit();
+
+    // Scale up by 2x in both dimensions
+    var scales_2d = [_]f32{ 2.0, 2.0 };
+    var resized_2d = try TensMath.resize(u8, &tensor_2d, "nearest", &scales_2d, null, "half_pixel");
+    defer resized_2d.deinit();
+
+    try std.testing.expectEqual(@as(usize, 16), resized_2d.size);
+    try std.testing.expectEqual(@as(usize, 4), resized_2d.shape[0]);
+    try std.testing.expectEqual(@as(usize, 4), resized_2d.shape[1]);
+}
+
+test "resize with linear interpolation" {
+    tests_log.info("\n     test: resize with linear interpolation", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Test 1D tensor resize
+    var input_array_1d = [_]u8{ 1, 2, 3, 4 };
+    var shape_1d = [_]usize{4};
+    var tensor_1d = try Tensor(u8).fromArray(&allocator, &input_array_1d, &shape_1d);
+    defer tensor_1d.deinit();
+
+    // Scale up by 2x
+    var scales = [_]f32{2.0};
+    var resized_1d = try TensMath.resize(u8, &tensor_1d, "linear", &scales, null, "half_pixel");
+    defer resized_1d.deinit();
+
+    try std.testing.expectEqual(@as(usize, 8), resized_1d.size);
+
+    // Test 2D tensor resize
+    var input_array_2d = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+    };
+    var shape_2d = [_]usize{ 2, 2 };
+    var tensor_2d = try Tensor(u8).fromArray(&allocator, &input_array_2d, &shape_2d);
+    defer tensor_2d.deinit();
+
+    // Scale up by 2x in both dimensions
+    var scales_2d = [_]f32{ 2.0, 2.0 };
+    var resized_2d = try TensMath.resize(u8, &tensor_2d, "linear", &scales_2d, null, "half_pixel");
+    defer resized_2d.deinit();
+
+    try std.testing.expectEqual(@as(usize, 16), resized_2d.size);
+    try std.testing.expectEqual(@as(usize, 4), resized_2d.shape[0]);
+    try std.testing.expectEqual(@as(usize, 4), resized_2d.shape[1]);
+}
+
+test "resize with cubic interpolation" {
+    tests_log.info("\n     test: resize with cubic interpolation", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Test 1D tensor resize
+    var input_array_1d = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    var shape_1d = [_]usize{8};
+    var tensor_1d = try Tensor(u8).fromArray(&allocator, &input_array_1d, &shape_1d);
+    defer tensor_1d.deinit();
+
+    // Scale down by 0.5x
+    var scales = [_]f32{0.5};
+    var resized_1d = try TensMath.resize(u8, &tensor_1d, "cubic", &scales, null, "half_pixel");
+    defer resized_1d.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), resized_1d.size);
+}
+
+test "resize with explicit sizes" {
+    tests_log.info("\n     test: resize with explicit sizes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var input_array = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+    };
+    var shape = [_]usize{ 2, 2 };
+    var tensor = try Tensor(u8).fromArray(&allocator, &input_array, &shape);
+    defer tensor.deinit();
+
+    // Resize to specific dimensions
+    var sizes = [_]usize{ 3, 3 };
+    var resized = try TensMath.resize(u8, &tensor, "nearest", null, &sizes, "half_pixel");
+    defer resized.deinit();
+
+    try std.testing.expectEqual(@as(usize, 9), resized.size);
+    try std.testing.expectEqual(@as(usize, 3), resized.shape[0]);
+    try std.testing.expectEqual(@as(usize, 3), resized.shape[1]);
+}
+
+test "resize error cases" {
+    tests_log.info("\n     test: resize error cases", .{});
+    const allocator = pkgAllocator.allocator;
+
+    var input_array = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+    };
+    var shape = [_]usize{ 2, 2 };
+    var tensor = try Tensor(u8).fromArray(&allocator, &input_array, &shape);
+    defer tensor.deinit();
+
+    // Test invalid mode
+    var scales = [_]f32{ 2.0, 2.0 };
+    try std.testing.expectError(
+        TensorError.UnsupportedMode,
+        TensMath.resize(u8, &tensor, "invalid_mode", &scales, null, "half_pixel"),
+    );
+
+    // Test both scales and sizes provided
+    var sizes = [_]usize{ 3, 3 };
+    try std.testing.expectError(
+        TensorError.InvalidInput,
+        TensMath.resize(u8, &tensor, "nearest", &scales, &sizes, "half_pixel"),
+    );
+
+    // Test neither scales nor sizes provided
+    try std.testing.expectError(
+        TensorError.InvalidInput,
+        TensMath.resize(u8, &tensor, "nearest", null, null, "half_pixel"),
+    );
+}

--- a/tests/Core/Tensor/TensorMath/test_op_split 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_split 2.zig
@@ -1,0 +1,286 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+const TensorError = zant.utils.error_handler.TensorError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "get_split_output_shapes()" {
+    tests_log.info("\n     test: get_split_output_shapes \n", .{});
+
+    const allocator = pkgAllocator.allocator;
+    var input_shape = [_]usize{ 2, 3, 4 };
+
+    // Test with null split_sizes (equal splits)
+    {
+        const output_shapes = try TensMath.get_split_output_shapes(&input_shape, 1, null, null);
+        defer {
+            for (output_shapes) |shape| {
+                allocator.free(shape);
+            }
+            allocator.free(output_shapes);
+        }
+
+        try std.testing.expectEqual(@as(usize, 1), output_shapes.len);
+        try std.testing.expectEqual(@as(usize, 3), output_shapes[0].len);
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[0][0]);
+        try std.testing.expectEqual(@as(usize, 3), output_shapes[0][1]);
+        try std.testing.expectEqual(@as(usize, 4), output_shapes[0][2]);
+    }
+
+    // Test with specific split_sizes
+    {
+        var split_sizes = [_]usize{ 1, 2 };
+        const output_shapes = try TensMath.get_split_output_shapes(&input_shape, 1, &split_sizes, null);
+        defer {
+            for (output_shapes) |shape| {
+                allocator.free(shape);
+            }
+            allocator.free(output_shapes);
+        }
+
+        try std.testing.expectEqual(@as(usize, 2), output_shapes.len);
+        try std.testing.expectEqual(@as(usize, 3), output_shapes[0].len);
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[0][0]);
+        try std.testing.expectEqual(@as(usize, 1), output_shapes[0][1]);
+        try std.testing.expectEqual(@as(usize, 4), output_shapes[0][2]);
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[1][1]);
+    }
+
+    // Test invalid axis
+    try std.testing.expectError(TensorError.InvalidAxis, TensMath.get_split_output_shapes(&input_shape, -4, null, null));
+    try std.testing.expectError(TensorError.InvalidAxis, TensMath.get_split_output_shapes(&input_shape, 3, null, null));
+
+    // Test invalid split sizes
+    var invalid_split_sizes = [_]usize{ 1, 1 };
+    try std.testing.expectError(TensorError.InvalidSplitSize, TensMath.get_split_output_shapes(&input_shape, 1, &invalid_split_sizes, null));
+}
+
+test "split basic test" {
+    tests_log.info("\n     test: split basic test", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x3 tensor
+    const input_array = [_][3]u8{
+        [_]u8{ 1, 2, 3 },
+        [_]u8{ 4, 5, 6 },
+    };
+    var shape = [_]usize{ 2, 3 };
+    var tensor = try Tensor(u8).fromArray(&allocator, &input_array, &shape);
+    defer tensor.deinit();
+
+    // Split along axis 0 (rows)
+    const split_tensors = try TensMath.split(u8, &tensor, 0, null); // Added num_outputs parameter
+    defer {
+        for (split_tensors) |*t| {
+            t.deinit();
+        }
+        allocator.free(split_tensors);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), split_tensors.len);
+    try std.testing.expectEqual(@as(usize, 2), split_tensors[0].shape[0]);
+    try std.testing.expectEqual(@as(usize, 3), split_tensors[0].shape[1]);
+    try std.testing.expectEqual(@as(u8, 1), split_tensors[0].data[0]);
+    try std.testing.expectEqual(@as(u8, 6), split_tensors[0].data[5]);
+}
+
+test "split with custom sizes" {
+    tests_log.info("\n     test: split with custom sizes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 4x2 tensor
+    const input_array = [_][2]u8{
+        [_]u8{ 1, 2 },
+        [_]u8{ 3, 4 },
+        [_]u8{ 5, 6 },
+        [_]u8{ 7, 8 },
+    };
+    var shape = [_]usize{ 4, 2 };
+    var tensor = try Tensor(u8).fromArray(&allocator, &input_array, &shape);
+    defer tensor.deinit();
+
+    // Split along axis 0 into [1,3] parts
+    const split_sizes = [_]usize{ 1, 3 };
+    const split_tensors = try TensMath.split(u8, &tensor, 0, &split_sizes); // Added num_outputs parameter
+    defer {
+        for (split_tensors) |*t| {
+            t.deinit();
+        }
+        allocator.free(split_tensors);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), split_tensors.len);
+
+    // First split should be 1x2
+    try std.testing.expectEqual(@as(usize, 1), split_tensors[0].shape[0]);
+    try std.testing.expectEqual(@as(usize, 2), split_tensors[0].shape[1]);
+    try std.testing.expectEqual(@as(u8, 1), split_tensors[0].data[0]);
+    try std.testing.expectEqual(@as(u8, 2), split_tensors[0].data[1]);
+
+    // Second split should be 3x2
+    try std.testing.expectEqual(@as(usize, 3), split_tensors[1].shape[0]);
+    try std.testing.expectEqual(@as(usize, 2), split_tensors[1].shape[1]);
+    try std.testing.expectEqual(@as(u8, 3), split_tensors[1].data[0]);
+    try std.testing.expectEqual(@as(u8, 8), split_tensors[1].data[5]);
+}
+
+test "split with negative axis" {
+    tests_log.info("\n     test: split with negative axis", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x4 tensor
+    const input_array = [_][4]u8{
+        [_]u8{ 1, 2, 3, 4 },
+        [_]u8{ 5, 6, 7, 8 },
+    };
+    var shape = [_]usize{ 2, 4 };
+    var tensor = try Tensor(u8).fromArray(&allocator, &input_array, &shape);
+    defer tensor.deinit();
+
+    // Split along axis -1 (last axis) into [2,2] parts
+    const split_sizes = [_]usize{ 2, 2 };
+    const split_tensors = try TensMath.split(u8, &tensor, -1, &split_sizes); // Added num_outputs parameter
+    defer {
+        for (split_tensors) |*t| {
+            t.deinit();
+        }
+        allocator.free(split_tensors);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), split_tensors.len);
+
+    // Both splits should be 2x2
+    for (split_tensors) |t| {
+        try std.testing.expectEqual(@as(usize, 2), t.shape[0]);
+        try std.testing.expectEqual(@as(usize, 2), t.shape[1]);
+    }
+
+    // Check first split
+    try std.testing.expectEqual(@as(u8, 1), split_tensors[0].data[0]);
+    try std.testing.expectEqual(@as(u8, 2), split_tensors[0].data[1]);
+    try std.testing.expectEqual(@as(u8, 5), split_tensors[0].data[2]);
+    try std.testing.expectEqual(@as(u8, 6), split_tensors[0].data[3]);
+
+    // Check second split
+    try std.testing.expectEqual(@as(u8, 3), split_tensors[1].data[0]);
+    try std.testing.expectEqual(@as(u8, 4), split_tensors[1].data[1]);
+    try std.testing.expectEqual(@as(u8, 7), split_tensors[1].data[2]);
+    try std.testing.expectEqual(@as(u8, 8), split_tensors[1].data[3]);
+}
+
+test "get_split_output_shapes - basic functionality" {
+    tests_log.info("\n     test: get_split_output_shapes - basic functionality", .{});
+
+    // Test case 1: Split along axis 1 - using shape that's evenly divisible by 2
+    {
+        var input_shape = [_]usize{ 4, 4, 2 }; // Change 3 to 4 so it's divisible by 2
+        // Explicitly request 2 output shapes by setting num_outputs
+        const output_shapes = try TensMath.get_split_output_shapes(&input_shape, 1, null, 2);
+        defer {
+            for (output_shapes) |shape| {
+                pkgAllocator.allocator.free(shape);
+            }
+            pkgAllocator.allocator.free(output_shapes);
+        }
+
+        try std.testing.expectEqual(@as(usize, 2), output_shapes.len);
+        // First split: [4, 2, 2]
+        try std.testing.expectEqual(@as(usize, 4), output_shapes[0][0]);
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[0][1]); // Half of 4
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[0][2]);
+        // Second split: [4, 2, 2]
+        try std.testing.expectEqual(@as(usize, 4), output_shapes[1][0]);
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[1][1]); // Half of 4
+        try std.testing.expectEqual(@as(usize, 2), output_shapes[1][2]);
+    }
+
+    // Test case 2: Split along last axis
+    {
+        var input_shape = [_]usize{ 2, 4 };
+        var split_sizes = [_]usize{ 2, 2 };
+        const output_shapes = try TensMath.get_split_output_shapes(&input_shape, 1, &split_sizes, null);
+        defer {
+            for (output_shapes) |shape| {
+                pkgAllocator.allocator.free(shape);
+            }
+            pkgAllocator.allocator.free(output_shapes);
+        }
+
+        try std.testing.expectEqual(@as(usize, 2), output_shapes.len);
+        // Both splits: [2, 2]
+        for (output_shapes) |shape| {
+            try std.testing.expectEqual(@as(usize, 2), shape[0]);
+            try std.testing.expectEqual(@as(usize, 2), shape[1]);
+        }
+    }
+}
+
+test "get_split_output_shapes - negative axis" {
+    tests_log.info("\n     test: get_split_output_shapes - negative axis", .{});
+
+    var input_shape = [_]usize{ 2, 6, 3 };
+    var split_sizes = [_]usize{ 2, 4 };
+
+    // Test with axis -2 (equivalent to axis 1)
+    const output_shapes = try TensMath.get_split_output_shapes(&input_shape, -2, &split_sizes, null);
+    defer {
+        for (output_shapes) |shape| {
+            pkgAllocator.allocator.free(shape);
+        }
+        pkgAllocator.allocator.free(output_shapes);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), output_shapes.len);
+    // First split: [2, 2, 3]
+    try std.testing.expectEqual(@as(usize, 2), output_shapes[0][0]);
+    try std.testing.expectEqual(@as(usize, 2), output_shapes[0][1]);
+    try std.testing.expectEqual(@as(usize, 3), output_shapes[0][2]);
+    // Second split: [2, 4, 3]
+    try std.testing.expectEqual(@as(usize, 2), output_shapes[1][0]);
+    try std.testing.expectEqual(@as(usize, 4), output_shapes[1][1]);
+    try std.testing.expectEqual(@as(usize, 3), output_shapes[1][2]);
+}
+
+test "get_split_output_shapes - error cases" {
+    tests_log.info("\n     test: get_split_output_shapes - error cases", .{});
+
+    var input_shape = [_]usize{ 2, 3, 4 };
+
+    // Test case 1: Invalid axis (too large)
+    {
+        var split_sizes = [_]usize{1};
+        try std.testing.expectError(TensorError.InvalidAxis, TensMath.get_split_output_shapes(&input_shape, 3, &split_sizes, null));
+    }
+
+    // Test case 2: Invalid axis (too negative)
+    {
+        var split_sizes = [_]usize{1};
+        try std.testing.expectError(TensorError.InvalidAxis, TensMath.get_split_output_shapes(&input_shape, -4, &split_sizes, null));
+    }
+
+    // Test case 3: Split sizes don't match dimension size
+    {
+        var split_sizes = [_]usize{ 1, 1 }; // Sum = 2, but dimension size is 3
+        try std.testing.expectError(TensorError.InvalidSplitSize, TensMath.get_split_output_shapes(&input_shape, 1, &split_sizes, null));
+    }
+
+    // Test case 4: Empty dimension
+    // It appears the function now handles empty shapes differently, so let's update the test
+    {
+        var empty_shape = [_]usize{ 0, 2 };
+        // Instead of expecting an error, let's verify it handles the case gracefully
+        const output_shapes = try TensMath.get_split_output_shapes(&empty_shape, 0, null, null);
+        defer {
+            for (output_shapes) |shape| {
+                pkgAllocator.allocator.free(shape);
+            }
+            pkgAllocator.allocator.free(output_shapes);
+        }
+        // Verify it returned an empty list or a list with a single empty shape
+        try std.testing.expect(output_shapes.len > 0);
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_op_squeeze 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_squeeze 2.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "Squeeze - Null axes (remove all size 1 dimensions)" {
+    tests_log.info("\n     test: Squeeze - Null axes (remove all size-1 dimensions) ", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Input shape: [1, 2, 1, 3]
+    var inputArray: [1][2][1][3]u8 = [_][2][1][3]u8{[_][1][3]u8{
+        [_][3]u8{
+            [_]u8{ 1, 2, 3 },
+        },
+        [_][3]u8{
+            [_]u8{ 4, 5, 6 },
+        },
+    }};
+    var shape: [4]usize = [_]usize{ 1, 2, 1, 3 };
+
+    var input = try Tensor(u8).fromArray(&allocator, &inputArray, &shape);
+    defer input.deinit();
+
+    var output = try TensMath.squeeze(u8, &input, null);
+    defer output.deinit();
+
+    // Expected output shape: [2, 3]
+    try std.testing.expect(output.shape.len == 2);
+    try std.testing.expect(output.shape[0] == 2);
+    try std.testing.expect(output.shape[1] == 3);
+    try std.testing.expect(output.size == 6);
+
+    // Expected values (unchanged)
+    try std.testing.expect(output.data[0] == 1);
+    try std.testing.expect(output.data[5] == 6);
+}
+
+test "Squeeze - Specific axis" {
+    tests_log.info("\n     test: Squeeze - Specific axis ", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Input shape: [1, 2, 1, 3]
+    var inputArray: [1][2][1][3]u8 = [_][2][1][3]u8{[_][1][3]u8{
+        [_][3]u8{
+            [_]u8{ 1, 2, 3 },
+        },
+        [_][3]u8{
+            [_]u8{ 4, 5, 6 },
+        },
+    }};
+    var shape: [4]usize = [_]usize{ 1, 2, 1, 3 };
+
+    var input = try Tensor(u8).fromArray(&allocator, &inputArray, &shape);
+    defer input.deinit();
+
+    // Squeeze axis 2
+    var output = try TensMath.squeeze(u8, &input, &.{2});
+    defer output.deinit();
+
+    // Expected output shape: [1, 2, 3]
+    try std.testing.expect(output.shape.len == 3);
+    try std.testing.expect(output.shape[0] == 1);
+    try std.testing.expect(output.shape[1] == 2);
+    try std.testing.expect(output.shape[2] == 3);
+    try std.testing.expect(output.size == 6);
+
+    // Expected values (unchanged)
+    try std.testing.expect(output.data[0] == 1.0);
+    try std.testing.expect(output.data[5] == 6.0);
+}
+
+test "Squeeze - Multiple axes" {
+    tests_log.info("\n     test: Squeeze - Multiple axes ", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Input shape: [1, 1, 2, 3, 1]
+    const inputArray: [1][1][2][3][1]u8 = [_][1][2][3][1]u8{
+        [_][2][3][1]u8{[_][3][1]u8{ [_][1]u8{ [_]u8{1}, [_]u8{2}, [_]u8{3} }, [_][1]u8{ [_]u8{4}, [_]u8{5}, [_]u8{6} } }},
+    };
+    var shape: [5]usize = [_]usize{ 1, 1, 2, 3, 1 };
+
+    var input = try Tensor(u8).fromArray(&allocator, &inputArray, &shape);
+    defer input.deinit();
+
+    // Squeeze axes 0, 1, rank-1=4
+    var output = try TensMath.squeeze(u8, &input, &.{ 0, 1, -1 });
+    defer output.deinit();
+
+    // Expected shape: [2, 3]
+    try std.testing.expect(output.shape.len == 2);
+    try std.testing.expect(output.shape[0] == 2);
+    try std.testing.expect(output.shape[1] == 3);
+    try std.testing.expect(output.size == 6);
+
+    // Expected values (unchanged)
+    try std.testing.expect(output.data[0] == 1);
+    try std.testing.expect(output.data[1] == 2);
+    try std.testing.expect(output.data[2] == 3);
+    try std.testing.expect(output.data[5] == 6);
+}
+
+test "Squeeze - Invalid axis (not size 1)" {
+    tests_log.info("\n     test: Squeeze - Invalid axis (not size 1) ", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Input shape: [1, 2, 1, 3]
+    var inputArray: [1][2][1][3]u8 = [_][2][1][3]u8{[_][1][3]u8{
+        [_][3]u8{
+            [_]u8{ 1, 2, 3 },
+        },
+        [_][3]u8{
+            [_]u8{ 4, 5, 6 },
+        },
+    }};
+    var shape: [4]usize = [_]usize{ 1, 2, 1, 3 };
+
+    var input = try Tensor(u8).fromArray(&allocator, &inputArray, &shape);
+    defer input.deinit();
+
+    // Try to squeeze axis 1 (but has size 2), should fail
+    try std.testing.expectError(TensorMathError.InvalidAxes, TensMath.squeeze(u8, &input, &.{1}));
+}
+
+test "Squeeze - Out of bounds axis" {
+    tests_log.info("\n     test: Squeeze - Out of bounds axis ", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Input shape: [1, 2]
+    const inputArray: [1][2]u8 = [_][2]u8{[_]u8{ 1, 2 }};
+    var shape: [2]usize = [_]usize{ 1, 2 };
+
+    var input = try Tensor(u8).fromArray(&allocator, &inputArray, &shape);
+    defer input.deinit();
+
+    // Try to squeeze axis 2 (but the rank is 2), should fail
+    try std.testing.expectError(TensorMathError.AxisOutOfRange, TensMath.squeeze(u8, &input, &.{2}));
+
+    // Try to squeeze axis rank-3=-1, should fail
+    try std.testing.expectError(TensorMathError.AxisOutOfRange, TensMath.squeeze(u8, &input, &.{-3}));
+}

--- a/tests/Core/Tensor/TensorMath/test_op_unsqueeze 2.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_unsqueeze 2.zig
@@ -1,0 +1,221 @@
+const std = @import("std");
+const zant = @import("zant");
+const pkgAllocator = zant.utils.allocator;
+const TensMath = zant.core.tensor.math_standard;
+const Tensor = zant.core.tensor.Tensor;
+const TensorMathError = zant.utils.error_handler.TensorMathError;
+const TensorError = zant.utils.error_handler.TensorError;
+
+const tests_log = std.log.scoped(.test_lib_shape);
+
+test "test unsqueeze axis out of bounds error" {
+    tests_log.info("\n test: unsqueeze axis out of bounds error\n", .{});
+    const allocator = std.testing.allocator;
+
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+    };
+    var inputShape: [2]usize = [_]usize{ 2, 3 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &inputShape);
+    defer tensor.deinit();
+
+    // 3 is not a valid axes {0, 1, 2} are valid
+    var axesArray: [1]i64 = [_]i64{3};
+    var axesShape: [1]usize = [_]usize{1};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.unsqueeze(f32, &tensor, &axesTensor));
+}
+
+// -------------------------------------------------------------
+// Test for DuplicateAxis error
+test "test unsqueeze duplicate axis error" {
+    tests_log.info("\n test: unsqueeze duplicate axis error\n", .{});
+    const allocator = std.testing.allocator;
+
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+    };
+    var inputShape: [2]usize = [_]usize{ 2, 3 };
+
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &inputShape);
+    defer tensor.deinit();
+
+    // Axes tensor contains a dupliacate
+    var axesArray: [2]i64 = [_]i64{ 0, 0 };
+    var axesShape: [1]usize = [_]usize{2};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    try std.testing.expectError(TensorError.DuplicateAxis, TensMath.unsqueeze(f32, &tensor, &axesTensor));
+}
+
+test "unsqueeze - basic" {
+    tests_log.info("\n     test: unsqueeze - basic", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x3 tensor
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 3 };
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    // Add dimension at axis 1
+    var axesArray: [1]i64 = [_]i64{1};
+    var axesShape: [1]usize = [_]usize{1};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    var result = try TensMath.unsqueeze(f32, &tensor, &axesTensor);
+    defer result.deinit();
+
+    // Expected shape: [2, 1, 3]
+    try std.testing.expect(result.shape.len == 3);
+    try std.testing.expect(result.shape[0] == 2);
+    try std.testing.expect(result.shape[1] == 1);
+    try std.testing.expect(result.shape[2] == 3);
+
+    // Data should be preserved
+    for (0..6) |i| {
+        try std.testing.expect(result.data[i] == tensor.data[i]);
+    }
+}
+
+test "unsqueeze - multiple axes" {
+    tests_log.info("\n     test: unsqueeze - multiple axes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x2 tensor
+    var inputArray: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 2 };
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    // Add dimensions at axes 0 and 2
+    var axesArray: [2]i64 = [_]i64{ 0, 2 };
+    var axesShape: [1]usize = [_]usize{2};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    var result = try TensMath.unsqueeze(f32, &tensor, &axesTensor);
+    defer result.deinit();
+
+    // Expected shape: [1, 2, 1, 2]
+    try std.testing.expect(result.shape.len == 4);
+    try std.testing.expect(result.shape[0] == 1);
+    try std.testing.expect(result.shape[1] == 2);
+    try std.testing.expect(result.shape[2] == 1);
+    try std.testing.expect(result.shape[3] == 2);
+
+    // Data should be preserved
+    for (0..4) |i| {
+        try std.testing.expect(result.data[i] == tensor.data[i]);
+    }
+}
+
+test "unsqueeze - negative axes" {
+    tests_log.info("\n     test: unsqueeze - negative axes", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x3 tensor
+    var inputArray: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 3 };
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    // Add dimension at axis -1 (equivalent to 2)
+    var axesArray: [1]i64 = [_]i64{-1};
+    var axesShape: [1]usize = [_]usize{1};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    var result = try TensMath.unsqueeze(f32, &tensor, &axesTensor);
+    defer result.deinit();
+
+    // Expected shape: [2, 3, 1]
+    try std.testing.expect(result.shape.len == 3);
+    try std.testing.expect(result.shape[0] == 2);
+    try std.testing.expect(result.shape[1] == 3);
+    try std.testing.expect(result.shape[2] == 1);
+
+    // Data should be preserved
+    for (0..6) |i| {
+        try std.testing.expect(result.data[i] == tensor.data[i]);
+    }
+}
+
+test "unsqueeze - scalar tensor" {
+    tests_log.info("\n     test: unsqueeze - scalar tensor", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 1x1 tensor
+    var inputArray: [1][1]f32 = [_][1]f32{[_]f32{42.0}};
+    var shape: [2]usize = [_]usize{ 1, 1 };
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    // Add dimensions at multiple positions
+    var axesArray: [3]i64 = [_]i64{ 0, 2, 3 };
+    var axesShape: [1]usize = [_]usize{3};
+    var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+    defer axesTensor.deinit();
+
+    var result = try TensMath.unsqueeze(f32, &tensor, &axesTensor);
+    defer result.deinit();
+
+    // Expected shape: [1, 1, 1, 1, 1]
+    try std.testing.expect(result.shape.len == 5);
+    for (result.shape) |dim| {
+        try std.testing.expect(dim == 1);
+    }
+
+    // Data should be preserved
+    try std.testing.expect(result.data[0] == 42.0);
+}
+
+test "unsqueeze - error cases" {
+    tests_log.info("\n     test: unsqueeze - error cases", .{});
+    const allocator = pkgAllocator.allocator;
+
+    // Create a 2x2 tensor
+    var inputArray: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 3.0, 4.0 },
+    };
+    var shape: [2]usize = [_]usize{ 2, 2 };
+    var tensor = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    defer tensor.deinit();
+
+    // Test 1: Invalid axis (too large)
+    {
+        var axesArray: [1]i64 = [_]i64{5};
+        var axesShape: [1]usize = [_]usize{1};
+        var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+        defer axesTensor.deinit();
+
+        try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.unsqueeze(f32, &tensor, &axesTensor));
+    }
+
+    // Test 2: Invalid axis (too negative)
+    {
+        var axesArray: [1]i64 = [_]i64{-5};
+        var axesShape: [1]usize = [_]usize{1};
+        var axesTensor = try Tensor(i64).fromArray(&allocator, &axesArray, &axesShape);
+        defer axesTensor.deinit();
+
+        try std.testing.expectError(TensorError.AxisOutOfBounds, TensMath.unsqueeze(f32, &tensor, &axesTensor));
+    }
+}

--- a/tests/Core/Tensor/TensorMath/test_tensor_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_tensor_math.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("test_op_concatenate.zig");
     // _ = @import("test_op_convolution.zig"); Tests are obsolete! The ops are tested into the fuzzing
     _ = @import("test_op_convolution_stm32n6.zig");
+    _ = @import("test_op_conv_clip.zig");
     _ = @import("test_op_flatten.zig");
     _ = @import("test_op_gather.zig");
     _ = @import("test_op_gelu.zig");

--- a/tests/Core/Tensor/TensorMath/test_tensor_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_tensor_math.zig
@@ -21,6 +21,7 @@ test {
     _ = @import("test_op_log.zig");
     _ = @import("test_op_mat_mul.zig");
     _ = @import("test_op_mean.zig");
+    _ = @import("test_op_min.zig");
     _ = @import("test_op_neg.zig");
     _ = @import("test_op_pad.zig");
     // _ = @import("test_op_pooling.zig"); Tests are obsolete! The ops are tested into the fuzzing

--- a/tests/ImageToTensor/test_imgToTensor 2.zig
+++ b/tests/ImageToTensor/test_imgToTensor 2.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const test_options = @import("test_options");
+const test_name = test_options.test_name;
+
+comptime {
+    _ = @import("jpeg/test_jpeg_decoder.zig");
+    _ = @import("test_utils.zig");
+}


### PR DESCRIPTION
Complete refactoring of the Conv+Clip operation and addition of new test cases.
The test file now includes a large number of tests, which may slow down execution — some of them can be commented out if needed.
The old Conv+Clip operation code is still available at the bottom of the file, fully commented out.
Finally, I’m not sure about the changes in other operation files — I didn’t touch any of them. 😅