### PR TITLE
Error management in codegenerated file–issue #496

### DIFF
--- a/src/IR_zant/fusion/WIP/fuse_custom_QAdd.zig
+++ b/src/IR_zant/fusion/WIP/fuse_custom_QAdd.zig
@@ -163,5 +163,5 @@ const Op_union = @import("../op_union/op_union.zig").Op_union;
 //     try writer.print("        &tensor_{s},\n", .{out_name});
 //     try writer.print("        {s},\n", .{c_scale_ref});
 //     try writer.print("        {s},\n", .{c_zp_ref});
-//     try writer.print("    ) catch return -1;\n", .{});
+//     try writer.print("    ) catch return {d};\n", .{utils.getMathErrorReturn()});
 // }

--- a/src/IR_zant/op_union/HOW_TO_ADD_MATHEMATICAL_OPERATIONS.md
+++ b/src/IR_zant/op_union/HOW_TO_ADD_MATHEMATICAL_OPERATIONS.md
@@ -81,13 +81,13 @@ Implement a write_op function in the struct to generate the operation’s implem
     _ = try writer.print(
             \\
             \\
-            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_A.ty.toString(),
             self.output_C.ty.toString(),
             tensor_A_string, // Input tensor A
             tensor_B_string, // Input tensor B
-            try IR_utils.getSanitizedName(self.output_C.name), // Output tensor C
+            try utils.getSanitizedName(self.output_C.name), // Output tensor C
             utils.getMathErrorReturn(), // Error code for math errors
         });
     ```

--- a/src/IR_zant/op_union/HOW_TO_ADD_MATHEMATICAL_OPERATIONS.md
+++ b/src/IR_zant/op_union/HOW_TO_ADD_MATHEMATICAL_OPERATIONS.md
@@ -76,7 +76,22 @@ Implement a write_op function in the struct to generate the operation’s implem
 - Generate a call to the lean version of the operation in 
 `src/core/Tensor/TensorMath`
 - Follow the patterns used for the other operations
-
+- Ensure that the generated code uses the updated error handling for the mathematical operation is failures, which should look like (following the `op_add` operator):
+    ```zig
+    _ = try writer.print(
+            \\
+            \\
+            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
+        , .{
+            self.input_A.ty.toString(),
+            self.output_C.ty.toString(),
+            tensor_A_string, // Input tensor A
+            tensor_B_string, // Input tensor B
+            try IR_utils.getSanitizedName(self.output_C.name), // Output tensor C
+            utils.getMathErrorReturn(), // Error code for math errors
+        });
+    ```
+    where `utils.getMathErrorReturn()` is a function from [IR_zant/utils.zig](../../../../Z-Ant/src/IR_zant/utils.zig) that returns the appropriate error code for mathematical operation failures (-101 if the first operation failed, -102 if the second one failed, etc.).
 
 
 

--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
@@ -210,7 +210,7 @@ pub const Fused_Conv_Clip = struct {
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.op_Conv.input_W.ty.toString(),
@@ -223,6 +223,7 @@ pub const Fused_Conv_Clip = struct {
                 target_type,
                 kernel_name,
                 kernel_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_kernel_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", kernel_name, "_casted)" });
             need_free_kernel = true;
@@ -239,7 +240,7 @@ pub const Fused_Conv_Clip = struct {
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.op_Conv.input_B.?.ty.toString(),
@@ -252,6 +253,7 @@ pub const Fused_Conv_Clip = struct {
                 target_type,
                 bias_name,
                 bias_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", bias_name, "_casted)" });
             need_free_bias = true;
@@ -277,7 +279,7 @@ pub const Fused_Conv_Clip = struct {
             \\        "{s}",
             \\        {s},
             \\        {s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
             \\
         , .{
             target_type,
@@ -292,6 +294,7 @@ pub const Fused_Conv_Clip = struct {
             self.op_Conv.auto_pad,
             min_string,
             max_string,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Clip.zig
@@ -210,7 +210,7 @@ pub const Fused_Conv_Clip = struct {
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.op_Conv.input_W.ty.toString(),
@@ -240,7 +240,7 @@ pub const Fused_Conv_Clip = struct {
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.op_Conv.input_B.?.ty.toString(),
@@ -279,7 +279,7 @@ pub const Fused_Conv_Clip = struct {
             \\        "{s}",
             \\        {s},
             \\        {s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
             \\
         , .{
             target_type,

--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Relu.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Relu.zig
@@ -10,7 +10,7 @@ const TensorCategory = tensorZant_lib.TensorCategory;
 const NodeZant_lib = IR_zant.NodeZant_lib;
 const NodeZant = NodeZant_lib.NodeZant;
 const GraphZant = IR_zant.GraphZant;
-const IR_utils = IR_zant.utils; //this is IR utils
+const utils = IR_zant.utils; //this is IR utils
 
 // --- union ---
 const Op_union = @import("../op_union.zig").Op_union;
@@ -169,11 +169,11 @@ pub const Fused_Conv_Relu = struct {
         if (self.op_Conv.input_X.tc == TensorCategory.INITIALIZER) {
             tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try IR_utils.getSanitizedName(self.op_Conv.input_X.name),
+                try utils.getSanitizedName(self.op_Conv.input_X.name),
                 ")",
             });
         } else {
-            tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try IR_utils.getSanitizedName(self.op_Conv.input_X.name), ")" });
+            tensor_X_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.op_Conv.input_X.name), ")" });
         }
 
         //----create tensor_W_string
@@ -182,18 +182,18 @@ pub const Fused_Conv_Relu = struct {
         if (self.op_Conv.input_W.tc == TensorCategory.INITIALIZER) {
             tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try IR_utils.getSanitizedName(self.op_Conv.input_W.name),
+                try utils.getSanitizedName(self.op_Conv.input_W.name),
                 ")",
             });
         } else {
-            tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try IR_utils.getSanitizedName(self.op_Conv.input_W.name), ")" });
+            tensor_W_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", try utils.getSanitizedName(self.op_Conv.input_W.name), ")" });
         }
 
         //----create ?bias string
         var bias_string: []u8 = undefined;
         // Bias Tensor B is optional! verify the presence
         if (self.op_Conv.input_B) |input_B| {
-            const B_name = try IR_utils.getSanitizedName(input_B.name);
+            const B_name = try utils.getSanitizedName(input_B.name);
             bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&param_lib.tensor_", B_name, ")" });
         } else {
             bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{"null"});
@@ -202,13 +202,13 @@ pub const Fused_Conv_Relu = struct {
         //----create stride string (mandatory)
         // TODO: implement default stride, see docs above
         if (self.op_Conv.strides == null) return error.StrideNotFound;
-        const stride_string: []const u8 = try IR_utils.i64SliceToUsizeArrayString(self.op_Conv.strides.?);
+        const stride_string: []const u8 = try utils.i64SliceToUsizeArrayString(self.op_Conv.strides.?);
 
         //----create ?pads string
         var pads_string: []const u8 = "null";
         if (self.op_Conv.pads != null) {
             if (self.op_Conv.pads.?.len > 0) { // Check if the slice is actually non-empty
-                pads_string = try IR_utils.i64SliceToUsizeArrayString(self.op_Conv.pads.?);
+                pads_string = try utils.i64SliceToUsizeArrayString(self.op_Conv.pads.?);
                 // Assuming no allocation needed to be freed, following write_conv
             } else {
                 pads_string = "&[_]usize{}"; // Use explicit empty slice literal if input slice is empty
@@ -219,7 +219,7 @@ pub const Fused_Conv_Relu = struct {
         var dilat_string: []const u8 = "null";
         if (self.op_Conv.dilations != null) {
             if (self.op_Conv.dilations.?.len > 0) {
-                dilat_string = try IR_utils.i64SliceToUsizeArrayString(self.op_Conv.dilations.?);
+                dilat_string = try utils.i64SliceToUsizeArrayString(self.op_Conv.dilations.?);
             } else {
                 dilat_string = "&[_]usize{}";
             }
@@ -239,13 +239,13 @@ pub const Fused_Conv_Relu = struct {
 
         if (need_kernel_cast) {
             // Generate cast for kernel
-            const kernel_name = try IR_utils.getSanitizedName(self.op_Conv.input_W.name);
+            const kernel_name = try utils.getSanitizedName(self.op_Conv.input_W.name);
             _ = try writer.print(
                 \\
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.op_Conv.input_W.ty.toString(),
@@ -258,6 +258,7 @@ pub const Fused_Conv_Relu = struct {
                 target_type,
                 kernel_name,
                 kernel_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_kernel_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", kernel_name, "_casted)" });
             need_free_kernel = true;
@@ -267,13 +268,13 @@ pub const Fused_Conv_Relu = struct {
 
         if (need_bias_cast and self.op_Conv.input_B != null) {
             // Generate cast for bias
-            const bias_name = try IR_utils.getSanitizedName(self.op_Conv.input_B.?.name);
+            const bias_name = try utils.getSanitizedName(self.op_Conv.input_B.?.name);
             _ = try writer.print(
                 \\
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.op_Conv.input_B.?.ty.toString(),
@@ -286,6 +287,7 @@ pub const Fused_Conv_Relu = struct {
                 target_type,
                 bias_name,
                 bias_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", bias_name, "_casted)" });
             need_free_bias = true;
@@ -309,18 +311,19 @@ pub const Fused_Conv_Relu = struct {
             \\        {s}, //dilatations
             \\        {}, //group
             \\        "{s}", //auto_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             target_type,
             tensor_X_string, //Input tensor
             final_kernel_string, //Kernel (possibly casted)
-            try IR_utils.getSanitizedName(self.op_Relu.output_Y.name), // Output tensor
+            try utils.getSanitizedName(self.op_Relu.output_Y.name), // Output tensor
             final_bias_string, //Bias (possibly casted)
             stride_string, //Strides
             pads_string, //Pads
             dilat_string, //Dilatations
             self.op_Conv.group, //Group
             self.op_Conv.auto_pad, //auto_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/fused_operators/fused_Conv_Relu.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Conv_Relu.zig
@@ -245,7 +245,7 @@ pub const Fused_Conv_Relu = struct {
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.op_Conv.input_W.ty.toString(),
@@ -274,7 +274,7 @@ pub const Fused_Conv_Relu = struct {
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.op_Conv.input_B.?.ty.toString(),
@@ -311,7 +311,7 @@ pub const Fused_Conv_Relu = struct {
             \\        {s}, //dilatations
             \\        {}, //group
             \\        "{s}", //auto_pad
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             target_type,
             tensor_X_string, //Input tensor

--- a/src/IR_zant/op_union/fused_operators/fused_Dequant_Clip_Quant.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Dequant_Clip_Quant.zig
@@ -304,7 +304,7 @@ pub const Fused_Dequant_Clip_Quant = struct {
             \\        @constCast({s}), // output tensor
             \\        {s}.data[0], // output_scale
             \\        {s}.data[0], // output_zero_point
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
             \\
         , .{
             input_quantized_tensor.ty.toString(),
@@ -316,6 +316,7 @@ pub const Fused_Dequant_Clip_Quant = struct {
             str_output_quantized,
             str_output_scale,
             str_output_zero_point,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/fused_operators/fused_Dequant_Clip_Quant.zig
+++ b/src/IR_zant/op_union/fused_operators/fused_Dequant_Clip_Quant.zig
@@ -304,7 +304,7 @@ pub const Fused_Dequant_Clip_Quant = struct {
             \\        @constCast({s}), // output tensor
             \\        {s}.data[0], // output_scale
             \\        {s}.data[0], // output_zero_point
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
             \\
         , .{
             input_quantized_tensor.ty.toString(),

--- a/src/IR_zant/op_union/op_template.md
+++ b/src/IR_zant/op_union/op_template.md
@@ -23,6 +23,7 @@ Each ONNX operator should be implemented as a `struct` that provides the followi
   Returns all the output tensors
 - `write_op(self: YourOpStruct, writer: *std.Io.Writer) !void`  
   Emits backend-compatible code that performs the actual tensor operation.
+  * Note that this function should generate a core call with catch for error handling where the return code for math errors should be consistent with the rest of the codebase, therefore it should use the `utils.getMathErrorReturn()` function to get the correct return code for math errors.
 
 - `compute_output_shape(self: YourOpStruct) []usize`  
   Computes the output tensor shape (may use broadcasting utilities).

--- a/src/IR_zant/op_union/operators/op_add.zig
+++ b/src/IR_zant/op_union/operators/op_add.zig
@@ -13,7 +13,7 @@ const TensorProto = onnx.TensorProto;
 const tensorZant = @import("../../tensorZant.zig");
 const TensorZant = tensorZant.TensorZant;
 const TensorCategory = tensorZant.TensorCategory;
-const IR_utils = @import("../../utils.zig"); //this is IR utils
+const utils = @import("../../utils.zig"); //this is IR utils
 
 // --- uops ---
 const cg_v2 = @import("codegen").codegen_v2;
@@ -80,11 +80,11 @@ pub const Add = struct {
         if (self.input_A.tc == TensorCategory.INITIALIZER) {
             tensor_A_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try IR_utils.getSanitizedName(self.input_A.name),
+                try utils.getSanitizedName(self.input_A.name),
                 ")",
             });
         } else {
-            tensor_A_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "&tensor_", try IR_utils.getSanitizedName(self.input_A.name) });
+            tensor_A_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "&tensor_", try utils.getSanitizedName(self.input_A.name) });
         }
 
         //----create tensor_B_string
@@ -93,29 +93,30 @@ pub const Add = struct {
         if (self.input_B.tc == TensorCategory.INITIALIZER) {
             tensor_B_string = try std.mem.concat(allocator, u8, &[_][]const u8{
                 "@constCast(&param_lib.tensor_",
-                try IR_utils.getSanitizedName(self.input_B.name),
+                try utils.getSanitizedName(self.input_B.name),
                 ")",
             });
         } else {
-            tensor_B_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "&tensor_", try IR_utils.getSanitizedName(self.input_B.name) });
+            tensor_B_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "&tensor_", try utils.getSanitizedName(self.input_B.name) });
         }
 
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_A.ty.toString(),
             self.output_C.ty.toString(),
             tensor_A_string, // Input tensor A
             tensor_B_string, // Input tensor B
-            try IR_utils.getSanitizedName(self.output_C.name), // Output tensor C
+            try utils.getSanitizedName(self.output_C.name), // Output tensor C
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 
     pub fn compute_output_shape(self: Add) []usize {
         var output_shape: []usize = undefined;
-        output_shape = try IR_utils.broadcastShapes(allocator, self.input_A.shape, self.input_B.shape);
+        output_shape = try utils.broadcastShapes(allocator, self.input_A.shape, self.input_B.shape);
         self.output_C.shape = output_shape;
         return output_shape;
     }
@@ -152,7 +153,7 @@ pub const Add = struct {
         const out_shape = self.get_output_shape();
         const strideA = self.input_A.stride;
         const strideB = self.input_B.stride;
-        const out_dtype = IR_utils.tensorTypeToDtype(self.output_C.ty);
+        const out_dtype = utils.tensorTypeToDtype(self.output_C.ty);
 
         lowerAdd(
             builder,

--- a/src/IR_zant/op_union/operators/op_add.zig
+++ b/src/IR_zant/op_union/operators/op_add.zig
@@ -103,7 +103,7 @@ pub const Add = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.sum_tensors_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_A.ty.toString(),
             self.output_C.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_averagePool.zig
+++ b/src/IR_zant/op_union/operators/op_averagePool.zig
@@ -188,7 +188,7 @@ pub const AveragePool = struct {
             \\        {s}, // pads
             \\        tensMath.op_averagePool.AutoPadType.{s}, // auto_pad
             \\        {s}, // count_include_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d}; 
         , .{
             self.input_X.ty.toString(),
             tensor_X_string, // Input
@@ -199,6 +199,7 @@ pub const AveragePool = struct {
             pads_string, // pads
             self.auto_pad, // auto_pad
             if (self.count_include_pad == 1) "true" else "false", // count_include_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_averagePool.zig
+++ b/src/IR_zant/op_union/operators/op_averagePool.zig
@@ -188,7 +188,7 @@ pub const AveragePool = struct {
             \\        {s}, // pads
             \\        tensMath.op_averagePool.AutoPadType.{s}, // auto_pad
             \\        {s}, // count_include_pad
-            \\    ) catch return -{d}; 
+            \\    ) catch return {d}; 
         , .{
             self.input_X.ty.toString(),
             tensor_X_string, // Input

--- a/src/IR_zant/op_union/operators/op_batchNormalization.zig
+++ b/src/IR_zant/op_union/operators/op_batchNormalization.zig
@@ -198,7 +198,7 @@ pub const BatchNormalization = struct {
             \\        {}, //momentum
             \\        false, //training_mode
             \\        &tensor_{s}, //output
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_X.ty.toString(),
             self.scale.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_batchNormalization.zig
+++ b/src/IR_zant/op_union/operators/op_batchNormalization.zig
@@ -198,7 +198,7 @@ pub const BatchNormalization = struct {
             \\        {}, //momentum
             \\        false, //training_mode
             \\        &tensor_{s}, //output
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             self.scale.ty.toString(),
@@ -211,6 +211,7 @@ pub const BatchNormalization = struct {
             self.epsilon,
             self.momentum,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_cast.zig
+++ b/src/IR_zant/op_union/operators/op_cast.zig
@@ -144,13 +144,14 @@ pub const Cast = struct {
             \\        {s}, // input tensor
             \\        &tensor_{s}, // output tensor
             \\        @enumFromInt({d}), // to DataType
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             input_type, // Input type
             output_type, // Output type
             tensor_input_string, // input tensor
             try utils.getSanitizedName(op.output.name), // output tensor
             op.to, // to attribute
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_cast.zig
+++ b/src/IR_zant/op_union/operators/op_cast.zig
@@ -144,7 +144,7 @@ pub const Cast = struct {
             \\        {s}, // input tensor
             \\        &tensor_{s}, // output tensor
             \\        @enumFromInt({d}), // to DataType
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             input_type, // Input type
             output_type, // Output type

--- a/src/IR_zant/op_union/operators/op_ceil.zig
+++ b/src/IR_zant/op_union/operators/op_ceil.zig
@@ -89,11 +89,12 @@ pub const Ceil = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.ceil_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.ceil_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_ceil.zig
+++ b/src/IR_zant/op_union/operators/op_ceil.zig
@@ -89,7 +89,7 @@ pub const Ceil = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.ceil_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.ceil_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_clip.zig
+++ b/src/IR_zant/op_union/operators/op_clip.zig
@@ -149,7 +149,7 @@ pub const Clip = struct {
             \\       {s},  //min tensor
             \\       {s},  //max tensor
             \\       &tensor_{s},  //output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
             \\
         , .{
             self.input.ty.toString(),
@@ -157,6 +157,7 @@ pub const Clip = struct {
             min_tensor_str,
             max_tensor_str,
             try utils.getSanitizedName(self.output.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 
@@ -201,7 +202,7 @@ pub const Clip = struct {
             \\        @constCast({s}), // output = input (in-place)
             \\        {s}.data[0], // output_scale
             \\        {s}.data[0], // output_zero_point
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
             \\
         , .{
             input_quantized_tensor.ty.toString(),
@@ -213,6 +214,7 @@ pub const Clip = struct {
             str_input_quantized,
             str_output_scale,
             str_output_zero_point,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_clip.zig
+++ b/src/IR_zant/op_union/operators/op_clip.zig
@@ -149,7 +149,7 @@ pub const Clip = struct {
             \\       {s},  //min tensor
             \\       {s},  //max tensor
             \\       &tensor_{s},  //output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
             \\
         , .{
             self.input.ty.toString(),
@@ -202,7 +202,7 @@ pub const Clip = struct {
             \\        @constCast({s}), // output = input (in-place)
             \\        {s}.data[0], // output_scale
             \\        {s}.data[0], // output_zero_point
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
             \\
         , .{
             input_quantized_tensor.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_concat.zig
+++ b/src/IR_zant/op_union/operators/op_concat.zig
@@ -179,12 +179,13 @@ pub const Concat = struct {
             \\}};
             \\
             \\    // Perform concatenation
-            \\    tensMath.concatenate_lean({s}, &allocator, &concat_tensor_list_{s}, {}, &tensor_{s} ) catch return -1;
+            \\    tensMath.concatenate_lean({s}, &allocator, &concat_tensor_list_{s}, {}, &tensor_{s} ) catch return -{d};
         , .{
             self.inputs.items[0].ty.toString(),
             try utils.getSanitizedName(self.concat_result.name),
             self.axis,
             try utils.getSanitizedName(self.concat_result.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_concat.zig
+++ b/src/IR_zant/op_union/operators/op_concat.zig
@@ -179,7 +179,7 @@ pub const Concat = struct {
             \\}};
             \\
             \\    // Perform concatenation
-            \\    tensMath.concatenate_lean({s}, &allocator, &concat_tensor_list_{s}, {}, &tensor_{s} ) catch return -{d};
+            \\    tensMath.concatenate_lean({s}, &allocator, &concat_tensor_list_{s}, {}, &tensor_{s} ) catch return {d};
         , .{
             self.inputs.items[0].ty.toString(),
             try utils.getSanitizedName(self.concat_result.name),

--- a/src/IR_zant/op_union/operators/op_constant.zig
+++ b/src/IR_zant/op_union/operators/op_constant.zig
@@ -124,7 +124,7 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    // Initialize scalar float constant
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, {d}) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, {d}) catch return {d};
             , .{
                 output_name,
                 self.output.ty.toString(),
@@ -150,7 +150,7 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return {d};
             , .{
                 output_name,
                 self.output.ty.toString(),
@@ -163,7 +163,7 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    // Initialize scalar int constant
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, @as(T, @floatFromInt({d}))) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, @as(T, @floatFromInt({d}))) catch return {d};
             , .{
                 output_name,
                 self.output.ty.toString(),
@@ -189,7 +189,7 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return {d};
             , .{
                 output_name,
                 self.output.ty.toString(),
@@ -203,7 +203,7 @@ pub const Constant = struct {
                 \\
                 \\    // String constants are not directly supported in this numeric tensor library
                 \\    // For now, we'll create a placeholder tensor with a single value
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return {d};
                 \\    // The actual string value was: "{s}"
             , .{
                 output_name,
@@ -231,7 +231,7 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return {d};
                 \\    // Note: This is a placeholder for string values that cannot be directly represented
             , .{
                 output_name,
@@ -246,7 +246,7 @@ pub const Constant = struct {
                 \\
                 \\    // Sparse tensor constants are not yet fully supported
                 \\    // Creating a placeholder tensor for sparse_value
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -{d};
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return {d};
                 \\    mathHandler_log.warn("Warning: sparse_value attribute used but not fully supported\\n", .{{}});
             , .{
                 output_name,

--- a/src/IR_zant/op_union/operators/op_constant.zig
+++ b/src/IR_zant/op_union/operators/op_constant.zig
@@ -124,11 +124,12 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    // Initialize scalar float constant
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, {d}) catch return -1;
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, {d}) catch return -{d};
             , .{
                 output_name,
                 self.output.ty.toString(),
                 self.value_float.?,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         } else if (self.value_floats != null) {
@@ -149,23 +150,25 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -1;
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
             , .{
                 output_name,
                 self.output.ty.toString(),
                 output_name,
                 self.value_floats.?.len,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         } else if (self.value_int != null) {
             try writer.print(
                 \\
                 \\    // Initialize scalar int constant
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, @as(T, @floatFromInt({d}))) catch return -1;
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, @as(T, @floatFromInt({d}))) catch return -{d};
             , .{
                 output_name,
                 self.output.ty.toString(),
                 self.value_int.?,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         } else if (self.value_ints != null) {
@@ -186,12 +189,13 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -1;
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
             , .{
                 output_name,
                 self.output.ty.toString(),
                 output_name,
                 self.value_ints.?.len,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         } else if (self.value_string != null) {
@@ -199,11 +203,12 @@ pub const Constant = struct {
                 \\
                 \\    // String constants are not directly supported in this numeric tensor library
                 \\    // For now, we'll create a placeholder tensor with a single value
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -1;
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -{d};
                 \\    // The actual string value was: "{s}"
             , .{
                 output_name,
                 self.output.ty.toString(),
+                utils.getMathErrorReturn(), // Error code for math errors
                 self.value_string.?,
             });
             return;
@@ -226,13 +231,14 @@ pub const Constant = struct {
             try writer.print(
                 \\
                 \\    }};
-                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -1;
+                \\    tensor_{s} = Tensor({s}).fromSlice(&allocator, &data_{s}, &[_]usize{{{d}}}) catch return -{d};
                 \\    // Note: This is a placeholder for string values that cannot be directly represented
             , .{
                 output_name,
                 self.output.ty.toString(),
                 output_name,
                 self.value_strings.?.len,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         } else if (self.sparse_value != null) {
@@ -240,11 +246,12 @@ pub const Constant = struct {
                 \\
                 \\    // Sparse tensor constants are not yet fully supported
                 \\    // Creating a placeholder tensor for sparse_value
-                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -1;
+                \\    tensor_{s} = Tensor({s}).initScalar(&allocator, 0) catch return -{d};
                 \\    mathHandler_log.warn("Warning: sparse_value attribute used but not fully supported\\n", .{{}});
             , .{
                 output_name,
                 self.output.ty.toString(),
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             return;
         }

--- a/src/IR_zant/op_union/operators/op_conv.zig
+++ b/src/IR_zant/op_union/operators/op_conv.zig
@@ -210,7 +210,7 @@ pub const Conv = struct {
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.input_W.ty.toString(),
@@ -239,7 +239,7 @@ pub const Conv = struct {
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 self.input_B.?.ty.toString(),
@@ -275,7 +275,7 @@ pub const Conv = struct {
             \\        {s}, //dilatations
             \\        {}, //group
             \\        "{s}", //auto_pad
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             target_type,
             tensor_X_string, //Input

--- a/src/IR_zant/op_union/operators/op_conv.zig
+++ b/src/IR_zant/op_union/operators/op_conv.zig
@@ -210,7 +210,7 @@ pub const Conv = struct {
                 \\    // Cast kernel from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.input_W.ty.toString(),
@@ -223,6 +223,7 @@ pub const Conv = struct {
                 target_type,
                 kernel_name,
                 kernel_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_kernel_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", kernel_name, "_casted)" });
             need_free_kernel = true;
@@ -238,7 +239,7 @@ pub const Conv = struct {
                 \\    // Cast bias from {s} to {s}
                 \\    var tensor_{s}_casted = Tensor({s}).fromShape(&allocator, @constCast(param_lib.tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&param_lib.tensor_{s}), &tensor_{s}_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 self.input_B.?.ty.toString(),
@@ -251,6 +252,7 @@ pub const Conv = struct {
                 target_type,
                 bias_name,
                 bias_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_bias_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", bias_name, "_casted)" });
             need_free_bias = true;
@@ -273,7 +275,7 @@ pub const Conv = struct {
             \\        {s}, //dilatations
             \\        {}, //group
             \\        "{s}", //auto_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             target_type,
             tensor_X_string, //Input
@@ -285,6 +287,7 @@ pub const Conv = struct {
             dilat_string, //Dilatations
             self.group, //Group
             self.auto_pad, //auto_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_convInteger.zig
+++ b/src/IR_zant/op_union/operators/op_convInteger.zig
@@ -391,7 +391,7 @@ pub const ConvInteger = struct {
             \\        {s}, // dilations
             \\        {d}, // group
             \\        "{s}", // auto_pad
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             input_type, // Input type
             weight_type, // Weight type

--- a/src/IR_zant/op_union/operators/op_convInteger.zig
+++ b/src/IR_zant/op_union/operators/op_convInteger.zig
@@ -391,7 +391,7 @@ pub const ConvInteger = struct {
             \\        {s}, // dilations
             \\        {d}, // group
             \\        "{s}", // auto_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             input_type, // Input type
             weight_type, // Weight type
@@ -405,6 +405,7 @@ pub const ConvInteger = struct {
             dilations_string, // dilations
             op.group, // group
             op.auto_pad, // auto_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_dequantize.zig
+++ b/src/IR_zant/op_union/operators/op_dequantize.zig
@@ -112,12 +112,13 @@ pub const Dequantize = struct {
             \\        {s}, //outputType 
             \\        {s}, //input 
             \\        {s}, //output
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input.ty.toString(),
             self.output.ty.toString(),
             input_tensor_string,
             output_tensor_string,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_dequantize.zig
+++ b/src/IR_zant/op_union/operators/op_dequantize.zig
@@ -112,7 +112,7 @@ pub const Dequantize = struct {
             \\        {s}, //outputType 
             \\        {s}, //input 
             \\        {s}, //output
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input.ty.toString(),
             self.output.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_dequantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_dequantizeLinear.zig
@@ -205,7 +205,7 @@ pub const DequantizeLinear = struct {
             \\                                 {},  // axis
             \\                                 {},  // block_size
             \\                                 &tensor_{s}, // y: output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.x.ty.toString(),
             self.y.ty.toString(),
@@ -216,6 +216,7 @@ pub const DequantizeLinear = struct {
             self.axis,
             self.block_size,
             try self.y.getNameSanitized(),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_dequantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_dequantizeLinear.zig
@@ -205,7 +205,7 @@ pub const DequantizeLinear = struct {
             \\                                 {},  // axis
             \\                                 {},  // block_size
             \\                                 &tensor_{s}, // y: output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.x.ty.toString(),
             self.y.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_div.zig
+++ b/src/IR_zant/op_union/operators/op_div.zig
@@ -127,7 +127,7 @@ pub const Div = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 a_type,
@@ -159,7 +159,7 @@ pub const Div = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 b_type,
@@ -184,7 +184,7 @@ pub const Div = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.div_lean({s}, {s}, ({s}), &tensor_{s}) catch return -{d};
+            \\    tensMath.div_lean({s}, {s}, ({s}), &tensor_{s}) catch return {d};
         , .{
             target_type,
             final_a_string, // Input tensor A (possibly casted)

--- a/src/IR_zant/op_union/operators/op_div.zig
+++ b/src/IR_zant/op_union/operators/op_div.zig
@@ -127,7 +127,7 @@ pub const Div = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 a_type,
@@ -142,6 +142,7 @@ pub const Div = struct {
                 prefix,
                 a_name,
                 a_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_a_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", a_name, "_A_casted)" });
             need_free_a = true;
@@ -158,7 +159,7 @@ pub const Div = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 b_type,
@@ -173,6 +174,7 @@ pub const Div = struct {
                 prefix,
                 b_name,
                 b_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_b_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", b_name, "_B_casted)" });
             need_free_b = true;
@@ -182,12 +184,13 @@ pub const Div = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.div_lean({s}, {s}, ({s}), &tensor_{s}) catch return -1;
+            \\    tensMath.div_lean({s}, {s}, ({s}), &tensor_{s}) catch return -{d};
         , .{
             target_type,
             final_a_string, // Input tensor A (possibly casted)
             final_b_string, // Input tensor B (possibly casted)
             try utils.getSanitizedName(self.output_C.name), // Output tensor C
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_dynamicQuantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_dynamicQuantizeLinear.zig
@@ -105,12 +105,13 @@ pub const DynamicQuantizeLinear = struct {
             \\        &tensor_{s}, // output y (u8)
             \\        &tensor_{s}, // output y_scale (f32)
             \\        &tensor_{s}, // output y_zero_point (u8)
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             tensor_x_string, // input x
             try utils.getSanitizedName(op.output_y.name), // output y
             try utils.getSanitizedName(op.output_y_scale.name), // output y_scale
             try utils.getSanitizedName(op.output_y_zero_point.name), // output y_zero_point
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_dynamicQuantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_dynamicQuantizeLinear.zig
@@ -105,7 +105,7 @@ pub const DynamicQuantizeLinear = struct {
             \\        &tensor_{s}, // output y (u8)
             \\        &tensor_{s}, // output y_scale (f32)
             \\        &tensor_{s}, // output y_zero_point (u8)
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             tensor_x_string, // input x
             try utils.getSanitizedName(op.output_y.name), // output y

--- a/src/IR_zant/op_union/operators/op_elu.zig
+++ b/src/IR_zant/op_union/operators/op_elu.zig
@@ -101,12 +101,13 @@ pub const Elu = struct {
             \\        {s}, // input
             \\        &tensor_{s}, // output
             \\        {d} // alpha
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
             self.alpha,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_elu.zig
+++ b/src/IR_zant/op_union/operators/op_elu.zig
@@ -101,7 +101,7 @@ pub const Elu = struct {
             \\        {s}, // input
             \\        &tensor_{s}, // output
             \\        {d} // alpha
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_exp.zig
+++ b/src/IR_zant/op_union/operators/op_exp.zig
@@ -86,7 +86,7 @@ pub const Exp = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         ,
             .{
                 self.input.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_exp.zig
+++ b/src/IR_zant/op_union/operators/op_exp.zig
@@ -86,12 +86,13 @@ pub const Exp = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         ,
             .{
                 self.input.ty.toString(),
                 tensor_input_string,
                 try utils.getSanitizedName(self.output.name),
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_flatten.zig
+++ b/src/IR_zant/op_union/operators/op_flatten.zig
@@ -110,7 +110,7 @@ pub const Flatten = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.flatten_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.flatten_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.data.ty.toString(),
             input_string,

--- a/src/IR_zant/op_union/operators/op_flatten.zig
+++ b/src/IR_zant/op_union/operators/op_flatten.zig
@@ -110,11 +110,12 @@ pub const Flatten = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.flatten_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.flatten_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.data.ty.toString(),
             input_string,
             output_name,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_floor.zig
+++ b/src/IR_zant/op_union/operators/op_floor.zig
@@ -89,11 +89,12 @@ pub const Floor = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.floor_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.floor_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_floor.zig
+++ b/src/IR_zant/op_union/operators/op_floor.zig
@@ -89,7 +89,7 @@ pub const Floor = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.floor_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.floor_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_gather.zig
+++ b/src/IR_zant/op_union/operators/op_gather.zig
@@ -176,7 +176,7 @@ pub const Gather = struct {
         _ = try writer.print(
             \\    
             \\
-            \\    const array_usize_{s}_{s}= utils.sliceToUsizeSlice(allocator, {s}.data) catch return -{d};
+            \\    const array_usize_{s}_{s}= utils.sliceToUsizeSlice(allocator, {s}.data) catch return {d};
             \\    defer allocator.free(array_usize_{s}_{s});
         , .{
             try self.input_B.getNameSanitized(), //array_usize_{s}_
@@ -190,7 +190,7 @@ pub const Gather = struct {
         _ = try writer.print(
             \\    
             \\
-            \\    var tensor_usize_{s}_{s} = Tensor(usize).fromArray(&allocator, array_usize_{s}_{s}, {s}.shape) catch return -{d};
+            \\    var tensor_usize_{s}_{s} = Tensor(usize).fromArray(&allocator, array_usize_{s}_{s}, {s}.shape) catch return {d};
             \\    defer tensor_usize_{s}_{s}.deinit();
         , .{
             try self.input_B.getNameSanitized(), //tensor_usize_{s}_
@@ -215,7 +215,7 @@ pub const Gather = struct {
             \\        &tensor_usize_{s}_{s}, 
             \\        {},
             \\        &tensor_{s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_A.ty.toString(),
             tensor_A_string,

--- a/src/IR_zant/op_union/operators/op_gather.zig
+++ b/src/IR_zant/op_union/operators/op_gather.zig
@@ -176,12 +176,13 @@ pub const Gather = struct {
         _ = try writer.print(
             \\    
             \\
-            \\    const array_usize_{s}_{s}= utils.sliceToUsizeSlice(allocator, {s}.data) catch return -1;
+            \\    const array_usize_{s}_{s}= utils.sliceToUsizeSlice(allocator, {s}.data) catch return -{d};
             \\    defer allocator.free(array_usize_{s}_{s});
         , .{
             try self.input_B.getNameSanitized(), //array_usize_{s}_
             output_C_name, //{s}
             input_B_data_ref, //{s}.data (with proper prefix)
+            utils.getMathErrorReturn(), // Error code for math errors
             try self.input_B.getNameSanitized(), //defer allocator.free(array_usize_{s}
             output_C_name, //{s});
         });
@@ -189,7 +190,7 @@ pub const Gather = struct {
         _ = try writer.print(
             \\    
             \\
-            \\    var tensor_usize_{s}_{s} = Tensor(usize).fromArray(&allocator, array_usize_{s}_{s}, {s}.shape) catch return -1;
+            \\    var tensor_usize_{s}_{s} = Tensor(usize).fromArray(&allocator, array_usize_{s}_{s}, {s}.shape) catch return -{d};
             \\    defer tensor_usize_{s}_{s}.deinit();
         , .{
             try self.input_B.getNameSanitized(), //tensor_usize_{s}_
@@ -197,6 +198,7 @@ pub const Gather = struct {
             try self.input_B.getNameSanitized(), //array_usize_{s}_
             output_C_name, //{s}
             input_B_data_ref, //{s}.shape (with proper prefix)
+            utils.getMathErrorReturn(), // Error code for math errors
             try self.input_B.getNameSanitized(), //defer tensor_usize_{s}_
             output_C_name, //{s}.deinit();
         });
@@ -213,7 +215,7 @@ pub const Gather = struct {
             \\        &tensor_usize_{s}_{s}, 
             \\        {},
             \\        &tensor_{s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_A.ty.toString(),
             tensor_A_string,
@@ -221,6 +223,7 @@ pub const Gather = struct {
             try utils.getSanitizedName(self.output_C.name),
             self.axis,
             output_name,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_gathernd.zig
+++ b/src/IR_zant/op_union/operators/op_gathernd.zig
@@ -127,12 +127,13 @@ pub const GatherND = struct {
             \\        {s}, // Data tensor
             \\        {s}, // Indices tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_data.ty.toString(),
             tensor_data_string,
             tensor_indices_string,
             try utils.getSanitizedName(self.output.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_gathernd.zig
+++ b/src/IR_zant/op_union/operators/op_gathernd.zig
@@ -127,7 +127,7 @@ pub const GatherND = struct {
             \\        {s}, // Data tensor
             \\        {s}, // Indices tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_data.ty.toString(),
             tensor_data_string,

--- a/src/IR_zant/op_union/operators/op_gelu.zig
+++ b/src/IR_zant/op_union/operators/op_gelu.zig
@@ -94,12 +94,13 @@ pub const Gelu = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.gelu_lean({s}, {s}, "{s}", &tensor_{s}) catch return -1;
+            \\    tensMath.gelu_lean({s}, {s}, "{s}", &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             self.approximate,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_gelu.zig
+++ b/src/IR_zant/op_union/operators/op_gelu.zig
@@ -94,7 +94,7 @@ pub const Gelu = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.gelu_lean({s}, {s}, "{s}", &tensor_{s}) catch return -{d};
+            \\    tensMath.gelu_lean({s}, {s}, "{s}", &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_gemm.zig
+++ b/src/IR_zant/op_union/operators/op_gemm.zig
@@ -179,7 +179,7 @@ pub const Gemm = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted_{s}, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 a_type,
@@ -215,7 +215,7 @@ pub const Gemm = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted_{s}, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 b_type,
@@ -251,7 +251,7 @@ pub const Gemm = struct {
                 \\    // Cast input C from {s} to {s}
                 \\    var tensor_{s}_C_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_C_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_C_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_C_casted_{s}, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 c_type,
@@ -280,7 +280,7 @@ pub const Gemm = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.gemm_lean({s}, {s}, {s}, {s}, {}, {}, {s}, {s}, &tensor_{s} ) catch return -{d};
+            \\    tensMath.gemm_lean({s}, {s}, {s}, {s}, {}, {}, {s}, {s}, &tensor_{s} ) catch return {d};
         , .{
             target_type, // T
             final_a_string, // Input tensor A (possibly casted)

--- a/src/IR_zant/op_union/operators/op_gemm.zig
+++ b/src/IR_zant/op_union/operators/op_gemm.zig
@@ -179,7 +179,7 @@ pub const Gemm = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted_{s}, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 a_type,
@@ -197,6 +197,7 @@ pub const Gemm = struct {
                 a_name,
                 a_name,
                 output_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_a_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", a_name, "_A_casted_", output_name, ")" });
             need_free_a = true;
@@ -214,7 +215,7 @@ pub const Gemm = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted_{s}, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 b_type,
@@ -232,6 +233,7 @@ pub const Gemm = struct {
                 b_name,
                 b_name,
                 output_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_b_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", b_name, "_B_casted_", output_name, ")" });
             need_free_b = true;
@@ -249,7 +251,7 @@ pub const Gemm = struct {
                 \\    // Cast input C from {s} to {s}
                 \\    var tensor_{s}_C_casted_{s} = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_C_casted_{s}.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_C_casted_{s}, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_C_casted_{s}, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 c_type,
@@ -267,6 +269,7 @@ pub const Gemm = struct {
                 c_name,
                 c_name,
                 output_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_c_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", c_name, "_C_casted_", output_name, ")" });
             need_free_c = true;
@@ -277,7 +280,7 @@ pub const Gemm = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.gemm_lean({s}, {s}, {s}, {s}, {}, {}, {s}, {s}, &tensor_{s} ) catch return -1;
+            \\    tensMath.gemm_lean({s}, {s}, {s}, {s}, {}, {}, {s}, {s}, &tensor_{s} ) catch return -{d};
         , .{
             target_type, // T
             final_a_string, // Input tensor A (possibly casted)
@@ -288,6 +291,7 @@ pub const Gemm = struct {
             if (self.transA) "true" else "false",
             if (self.transB) "true" else "false",
             try utils.getSanitizedName(self.output.name), // Output
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_globalAveragePool.zig
+++ b/src/IR_zant/op_union/operators/op_globalAveragePool.zig
@@ -119,7 +119,7 @@ pub const GlobalAveragePool = struct {
 
         _ = try writer.print(
             \\
-            \\ tensMath.globalAveragePool_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\ tensMath.globalAveragePool_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_globalAveragePool.zig
+++ b/src/IR_zant/op_union/operators/op_globalAveragePool.zig
@@ -119,11 +119,12 @@ pub const GlobalAveragePool = struct {
 
         _ = try writer.print(
             \\
-            \\ tensMath.globalAveragePool_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\ tensMath.globalAveragePool_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_identity.zig
+++ b/src/IR_zant/op_union/operators/op_identity.zig
@@ -89,7 +89,7 @@ pub const Identity = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.identity_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.identity_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_identity.zig
+++ b/src/IR_zant/op_union/operators/op_identity.zig
@@ -89,11 +89,12 @@ pub const Identity = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.identity_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.identity_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_leakyRelu.zig
+++ b/src/IR_zant/op_union/operators/op_leakyRelu.zig
@@ -91,7 +91,7 @@ pub const LeakyRelu = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.leakyReLU_lean({s}, {s}, {d}, &tensor_{s}) catch return -{d};
+            \\    tensMath.leakyReLU_lean({s}, {s}, {d}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_leakyRelu.zig
+++ b/src/IR_zant/op_union/operators/op_leakyRelu.zig
@@ -91,12 +91,13 @@ pub const LeakyRelu = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.leakyReLU_lean({s}, {s}, {d}, &tensor_{s}) catch return -1;
+            \\    tensMath.leakyReLU_lean({s}, {s}, {d}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             self.alpha,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_log.zig
+++ b/src/IR_zant/op_union/operators/op_log.zig
@@ -86,7 +86,7 @@ pub const Log = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         ,
             .{
                 self.input.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_log.zig
+++ b/src/IR_zant/op_union/operators/op_log.zig
@@ -86,12 +86,13 @@ pub const Log = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         ,
             .{
                 self.input.ty.toString(),
                 tensor_input_string,
                 try utils.getSanitizedName(self.output.name),
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_matMul.zig
+++ b/src/IR_zant/op_union/operators/op_matMul.zig
@@ -137,22 +137,24 @@ pub const MatMul = struct {
                 \\          {s}, 
                 \\          {s},
                 \\          &tensor_{s},
-                \\    ) catch return -1;
+                \\    ) catch return -{d};
             , .{
                 self.input_A.ty.toString(), // Input tensor type
                 tensor_A_string, // Input tensor A
                 tensor_B_string, // Input tensor B
                 try utils.getSanitizedName(self.output_C.name), // Output tensor C
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         } else { //B is not large enough, so we keep the old but improved mat_mul
             _ = try writer.print(
                 \\
-                \\    tensMath.mat_mul_lean({s}, {s}, {s}, &tensor_{s}) catch return -1;
+                \\    tensMath.mat_mul_lean({s}, {s}, {s}, &tensor_{s}) catch return -{d};
             , .{
                 self.output_C.ty.toString(),
                 tensor_A_string, // Input tensor A
                 tensor_B_string, // Input tensor B
                 try utils.getSanitizedName(self.output_C.name), // Output tensor C
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         }
     }

--- a/src/IR_zant/op_union/operators/op_matMul.zig
+++ b/src/IR_zant/op_union/operators/op_matMul.zig
@@ -137,7 +137,7 @@ pub const MatMul = struct {
                 \\          {s}, 
                 \\          {s},
                 \\          &tensor_{s},
-                \\    ) catch return -{d};
+                \\    ) catch return {d};
             , .{
                 self.input_A.ty.toString(), // Input tensor type
                 tensor_A_string, // Input tensor A
@@ -148,7 +148,7 @@ pub const MatMul = struct {
         } else { //B is not large enough, so we keep the old but improved mat_mul
             _ = try writer.print(
                 \\
-                \\    tensMath.mat_mul_lean({s}, {s}, {s}, &tensor_{s}) catch return -{d};
+                \\    tensMath.mat_mul_lean({s}, {s}, {s}, &tensor_{s}) catch return {d};
             , .{
                 self.output_C.ty.toString(),
                 tensor_A_string, // Input tensor A

--- a/src/IR_zant/op_union/operators/op_maxPool.zig
+++ b/src/IR_zant/op_union/operators/op_maxPool.zig
@@ -190,7 +190,7 @@ pub const MaxPool = struct {
             \\        {s}, //dilations
             \\        {s}, //pads
             \\        tensMath.op_maxPool.AutoPadType.{s}, //auto_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.output_Y.ty.toString(),
             tensor_X_string, //Input
@@ -200,6 +200,7 @@ pub const MaxPool = struct {
             dilations_string, //dilatations
             pads_string, //pads
             self.auto_pad, //auto_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_maxPool.zig
+++ b/src/IR_zant/op_union/operators/op_maxPool.zig
@@ -190,7 +190,7 @@ pub const MaxPool = struct {
             \\        {s}, //dilations
             \\        {s}, //pads
             \\        tensMath.op_maxPool.AutoPadType.{s}, //auto_pad
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.output_Y.ty.toString(),
             tensor_X_string, //Input

--- a/src/IR_zant/op_union/operators/op_min.zig
+++ b/src/IR_zant/op_union/operators/op_min.zig
@@ -122,7 +122,7 @@ pub const Min = struct {
                 \\        {s}, // First input
                 \\        {s}, // Second input
                 \\        &tensor_{s} // Output
-                \\    ) catch return -{d};
+                \\    ) catch return {d};
             , .{
                 self.inputs[0].ty.toString(),
                 tensor1_string,
@@ -163,7 +163,7 @@ pub const Min = struct {
                 \\            {s},
                 \\            &min_inputs,
                 \\            &tensor_{s}
-                \\        ) catch return -{d};
+                \\        ) catch return {d};
                 \\    }}
             , .{
                 self.inputs[0].ty.toString(),

--- a/src/IR_zant/op_union/operators/op_min.zig
+++ b/src/IR_zant/op_union/operators/op_min.zig
@@ -122,12 +122,13 @@ pub const Min = struct {
                 \\        {s}, // First input
                 \\        {s}, // Second input
                 \\        &tensor_{s} // Output
-                \\    ) catch return -1;
+                \\    ) catch return -{d};
             , .{
                 self.inputs[0].ty.toString(),
                 tensor1_string,
                 tensor2_string,
                 try utils.getSanitizedName(self.output.name),
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         } else {
             // For multiple inputs, we need to create an array
@@ -162,11 +163,12 @@ pub const Min = struct {
                 \\            {s},
                 \\            &min_inputs,
                 \\            &tensor_{s}
-                \\        ) catch return -1;
+                \\        ) catch return -{d};
                 \\    }}
             , .{
                 self.inputs[0].ty.toString(),
                 try utils.getSanitizedName(self.output.name),
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         }
     }

--- a/src/IR_zant/op_union/operators/op_mul.zig
+++ b/src/IR_zant/op_union/operators/op_mul.zig
@@ -110,12 +110,13 @@ pub const Mul = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.mul_lean({s}, {s}, ({s}), &tensor_{s}) catch return -1;
+            \\    tensMath.mul_lean({s}, {s}, ({s}), &tensor_{s}) catch return -{d};
         , .{
             self.input_A.ty.toString(),
             tensor_A_string, // Input tensor A
             tensor_B_string, // Input tensor B
             try utils.getSanitizedName(self.output_C.name), // Output tensor C
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_mul.zig
+++ b/src/IR_zant/op_union/operators/op_mul.zig
@@ -110,7 +110,7 @@ pub const Mul = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.mul_lean({s}, {s}, ({s}), &tensor_{s}) catch return -{d};
+            \\    tensMath.mul_lean({s}, {s}, ({s}), &tensor_{s}) catch return {d};
         , .{
             self.input_A.ty.toString(),
             tensor_A_string, // Input tensor A

--- a/src/IR_zant/op_union/operators/op_neg.zig
+++ b/src/IR_zant/op_union/operators/op_neg.zig
@@ -89,7 +89,7 @@ pub const Neg = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.neg_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.neg_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_neg.zig
+++ b/src/IR_zant/op_union/operators/op_neg.zig
@@ -89,11 +89,12 @@ pub const Neg = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.neg_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.neg_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_nonmaxsuppression.zig
+++ b/src/IR_zant/op_union/operators/op_nonmaxsuppression.zig
@@ -207,7 +207,7 @@ pub const NonMaxSuppression = struct {
             \\      {s},
             \\      {s},
             \\      {d},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         ,
             .{
                 self.boxes.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_nonmaxsuppression.zig
+++ b/src/IR_zant/op_union/operators/op_nonmaxsuppression.zig
@@ -207,7 +207,7 @@ pub const NonMaxSuppression = struct {
             \\      {s},
             \\      {s},
             \\      {d},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         ,
             .{
                 self.boxes.ty.toString(),
@@ -218,6 +218,7 @@ pub const NonMaxSuppression = struct {
                 iou_thresh,
                 score_thresh,
                 self.center_point_box,
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_oneHot.zig
+++ b/src/IR_zant/op_union/operators/op_oneHot.zig
@@ -161,7 +161,7 @@ pub const OneHot = struct {
             \\        {s}, // values
             \\        {?}, // axis
             \\        &tensor_{s}, // output
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.values.ty.toString(), // T
             indices_string, // indices
@@ -169,6 +169,7 @@ pub const OneHot = struct {
             values_string, // values
             self.axis, // axis
             try utils.getSanitizedName(self.output.name), // output
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_oneHot.zig
+++ b/src/IR_zant/op_union/operators/op_oneHot.zig
@@ -161,7 +161,7 @@ pub const OneHot = struct {
             \\        {s}, // values
             \\        {?}, // axis
             \\        &tensor_{s}, // output
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.values.ty.toString(), // T
             indices_string, // indices

--- a/src/IR_zant/op_union/operators/op_pad.zig
+++ b/src/IR_zant/op_union/operators/op_pad.zig
@@ -273,7 +273,7 @@ pub const Pad = struct {
             \\        {s},
             \\        &tensor_{s},
             \\        "{s}"
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             op.output.ty.toString(),
             data_ref,
@@ -282,6 +282,7 @@ pub const Pad = struct {
             axes_ref,
             out_name,
             op.mode,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_pad.zig
+++ b/src/IR_zant/op_union/operators/op_pad.zig
@@ -273,7 +273,7 @@ pub const Pad = struct {
             \\        {s},
             \\        &tensor_{s},
             \\        "{s}"
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             op.output.ty.toString(),
             data_ref,

--- a/src/IR_zant/op_union/operators/op_pow.zig
+++ b/src/IR_zant/op_union/operators/op_pow.zig
@@ -128,7 +128,7 @@ pub const Pow = struct {
         //    \\    // Cast input X from {s} to {s}
         //   \\    var tensor_{s}_X_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
         //   \\    defer tensor_{s}_X_casted.deinit();
-        //    \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_X_casted, zant.onnx.DataType.FLOAT) catch return -1;
+        //    \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_X_casted, zant.onnx.DataType.FLOAT) catch return {d};
         //    \\
         //, .{
         //    x_type,
@@ -143,6 +143,7 @@ pub const Pow = struct {
         //    prefix,
         //    x_name,
         //    x_name,
+        //    utils.getMathErrorReturn(), // Error code for math errors
         //});
         //final_x_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", x_name, "_X_casted)" });
         //need_free_x = true;
@@ -152,7 +153,7 @@ pub const Pow = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.pow_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.pow_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return {d};
         , .{
             target_type,
             Y_type,

--- a/src/IR_zant/op_union/operators/op_pow.zig
+++ b/src/IR_zant/op_union/operators/op_pow.zig
@@ -152,13 +152,14 @@ pub const Pow = struct {
 
         _ = try writer.print(
             \\
-            \\    tensMath.pow_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.pow_lean({s}, {s}, {s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             target_type,
             Y_type,
             tensor_X_string, //input x doesn't need casting
             tensor_Y_string, //input y doesn't need casting
             try utils.getSanitizedName(self.Z.name), // Output tensor Z
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_qgemm.zig
+++ b/src/IR_zant/op_union/operators/op_qgemm.zig
@@ -248,7 +248,7 @@ pub const QGemm = struct {
             \\        {s},
             \\        {s},
             \\        {s}
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             tensor_a_string,
             tensor_a_scale_string,

--- a/src/IR_zant/op_union/operators/op_qgemm.zig
+++ b/src/IR_zant/op_union/operators/op_qgemm.zig
@@ -235,18 +235,32 @@ pub const QGemm = struct {
         }
 
         // Write the operation call
-        try writer.print("\n    // QGemm operation: quantized matrix multiplication (bias ignored for now)\n", .{});
-        try writer.print("    tensMath.qgemm_lean(\n", .{});
-        try writer.print("        {s},\n", .{tensor_a_string});
-        try writer.print("        {s},\n", .{tensor_a_scale_string});
-        try writer.print("        {s},\n", .{tensor_a_zero_point_string});
-        try writer.print("        {s},\n", .{tensor_b_string});
-        try writer.print("        {s},\n", .{tensor_b_scale_string});
-        try writer.print("        {s},\n", .{tensor_b_zero_point_string});
-        try writer.print("        {s},\n", .{tensor_output_string});
-        try writer.print("        {s},\n", .{tensor_y_scale_string});
-        try writer.print("        {s}\n", .{tensor_y_zero_point_string});
-        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
+        try writer.print(
+            \\
+            \\    // QGemm operation: quantized matrix multiplication (bias ignored for now)
+            \\    tensMath.qgemm_lean(
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s}
+            \\    ) catch return -{d};
+        , .{
+            tensor_a_string,
+            tensor_a_scale_string,
+            tensor_a_zero_point_string,
+            tensor_b_string,
+            tensor_b_scale_string,
+            tensor_b_zero_point_string,
+            tensor_output_string,
+            tensor_y_scale_string,
+            tensor_y_zero_point_string,
+            utils.getMathErrorReturn(),
+        });
 
         // Skip deallocation of input tensor to avoid FixedBufferAllocator issues
         // Input tensors will be deallocated by the general tensor management system

--- a/src/IR_zant/op_union/operators/op_qgemm.zig
+++ b/src/IR_zant/op_union/operators/op_qgemm.zig
@@ -246,7 +246,7 @@ pub const QGemm = struct {
         try writer.print("        {s},\n", .{tensor_output_string});
         try writer.print("        {s},\n", .{tensor_y_scale_string});
         try writer.print("        {s}\n", .{tensor_y_zero_point_string});
-        try writer.print("    ) catch return -1;\n", .{});
+        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
 
         // Skip deallocation of input tensor to avoid FixedBufferAllocator issues
         // Input tensors will be deallocated by the general tensor management system

--- a/src/IR_zant/op_union/operators/op_qlinearMul.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearMul.zig
@@ -223,7 +223,7 @@ pub const QLinearMul = struct {
 
         switch (op.input_A.ty) {
             .u8 => {
-                try writer.print("    tensMath.qlinearmul_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -{d};\n", .{
+                try writer.print("    tensMath.qlinearmul_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return {d};\n", .{
                     tensor_A_string,
                     tensor_A_scale_string,
                     tensor_A_zero_point_string,
@@ -237,7 +237,7 @@ pub const QLinearMul = struct {
                 });
             },
             .i8 => {
-                try writer.print("    tensMath.qlinearmul_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -{d};\n", .{
+                try writer.print("    tensMath.qlinearmul_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return {d};\n", .{
                     tensor_A_string,
                     tensor_A_scale_string,
                     tensor_A_zero_point_string,

--- a/src/IR_zant/op_union/operators/op_qlinearMul.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearMul.zig
@@ -223,7 +223,7 @@ pub const QLinearMul = struct {
 
         switch (op.input_A.ty) {
             .u8 => {
-                try writer.print("    tensMath.qlinearmul_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -1;\n", .{
+                try writer.print("    tensMath.qlinearmul_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -{d};\n", .{
                     tensor_A_string,
                     tensor_A_scale_string,
                     tensor_A_zero_point_string,
@@ -233,10 +233,11 @@ pub const QLinearMul = struct {
                     tensor_C_scale_string,
                     tensor_C_zero_point_string,
                     tensor_output_string,
+                    utils.getMathErrorReturn(), // Error code for math errors
                 });
             },
             .i8 => {
-                try writer.print("    tensMath.qlinearmul_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -1;\n", .{
+                try writer.print("    tensMath.qlinearmul_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}, {s}) catch return -{d};\n", .{
                     tensor_A_string,
                     tensor_A_scale_string,
                     tensor_A_zero_point_string,
@@ -246,6 +247,7 @@ pub const QLinearMul = struct {
                     tensor_C_scale_string,
                     tensor_C_zero_point_string,
                     tensor_output_string,
+                    utils.getMathErrorReturn(), // Error code for math errors
                 });
             },
             else => return error.UnsupportedDataType,

--- a/src/IR_zant/op_union/operators/op_qlinearSoftmax.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearSoftmax.zig
@@ -198,7 +198,7 @@ pub const QLinearSoftmax = struct {
 
         switch (op.input_x.ty) {
             .u8 => {
-                try writer.print("    tensMath.qlinearsoftmax_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -{d};\n", .{
+                try writer.print("    tensMath.qlinearsoftmax_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return {d};\n", .{
                     tensor_x_string,
                     tensor_x_scale_string,
                     tensor_x_zero_point_string,
@@ -210,7 +210,7 @@ pub const QLinearSoftmax = struct {
                 });
             },
             .i8 => {
-                try writer.print("    tensMath.qlinearsoftmax_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -{d};\n", .{
+                try writer.print("    tensMath.qlinearsoftmax_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return {d};\n", .{
                     tensor_x_string,
                     tensor_x_scale_string,
                     tensor_x_zero_point_string,

--- a/src/IR_zant/op_union/operators/op_qlinearSoftmax.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearSoftmax.zig
@@ -198,7 +198,7 @@ pub const QLinearSoftmax = struct {
 
         switch (op.input_x.ty) {
             .u8 => {
-                try writer.print("    tensMath.qlinearsoftmax_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -1;\n", .{
+                try writer.print("    tensMath.qlinearsoftmax_lean(u8, f32, u8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -{d};\n", .{
                     tensor_x_string,
                     tensor_x_scale_string,
                     tensor_x_zero_point_string,
@@ -206,10 +206,11 @@ pub const QLinearSoftmax = struct {
                     tensor_y_zero_point_string,
                     tensor_output_string,
                     axis_eff,
+                    utils.getMathErrorReturn(), // Error code for math errors
                 });
             },
             .i8 => {
-                try writer.print("    tensMath.qlinearsoftmax_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -1;\n", .{
+                try writer.print("    tensMath.qlinearsoftmax_lean(i8, f32, i8, {s}, {s}, {s}, {s}, {s}, {s}, {d}) catch return -{d};\n", .{
                     tensor_x_string,
                     tensor_x_scale_string,
                     tensor_x_zero_point_string,
@@ -217,6 +218,7 @@ pub const QLinearSoftmax = struct {
                     tensor_y_zero_point_string,
                     tensor_output_string,
                     axis_eff,
+                    utils.getMathErrorReturn(), // Error code for math errors
                 });
             },
             else => return error.UnsupportedDataType,

--- a/src/IR_zant/op_union/operators/op_qlinearadd.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearadd.zig
@@ -190,7 +190,7 @@ pub const QLinearAdd = struct {
             \\        &tensor_{s},
             \\        {s},
             \\        {s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             tensor_A_string,
             tensor_A_scale_string,

--- a/src/IR_zant/op_union/operators/op_qlinearadd.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearadd.zig
@@ -178,17 +178,31 @@ pub const QLinearAdd = struct {
         }
 
         // Write the operation call
-        try writer.print("\n    tensMath.qlinearadd_lean(\n", .{});
-        try writer.print("        {s},\n", .{tensor_A_string});
-        try writer.print("        {s},\n", .{tensor_A_scale_string});
-        try writer.print("        {s},\n", .{tensor_A_zero_point_string});
-        try writer.print("        {s},\n", .{tensor_B_string});
-        try writer.print("        {s},\n", .{tensor_B_scale_string});
-        try writer.print("        {s},\n", .{tensor_B_zero_point_string});
-        try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_C.name)});
-        try writer.print("        {s},\n", .{tensor_C_scale_string});
-        try writer.print("        {s},\n", .{tensor_C_zero_point_string});
-        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
+        try writer.print(
+            \\
+            \\    tensMath.qlinearadd_lean(
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        &tensor_{s},
+            \\        {s},
+            \\        {s},
+            \\    ) catch return -{d};
+        , .{
+            tensor_A_string,
+            tensor_A_scale_string,
+            tensor_A_zero_point_string,
+            tensor_B_string,
+            tensor_B_scale_string,
+            tensor_B_zero_point_string,
+            try utils.getSanitizedName(self.output_C.name),
+            tensor_C_scale_string,
+            tensor_C_zero_point_string,
+            utils.getMathErrorReturn(),
+        });
     }
 
     pub fn compute_output_shape(self: QLinearAdd) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearadd.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearadd.zig
@@ -188,7 +188,7 @@ pub const QLinearAdd = struct {
         try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_C.name)});
         try writer.print("        {s},\n", .{tensor_C_scale_string});
         try writer.print("        {s},\n", .{tensor_C_zero_point_string});
-        try writer.print("    ) catch return -1;\n", .{});
+        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
     }
 
     pub fn compute_output_shape(self: QLinearAdd) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearaveragepool.zig
@@ -305,7 +305,7 @@ pub const QLinearAveragePool = struct {
 
         _ = try writer.print(",\n        auto_pad_{s}", .{try utils.getSanitizedName(self.output_Y.name)});
         _ = try writer.print(",\n        {}", .{self.count_include_pad != 0});
-        _ = try writer.print(",\n    ) catch return -1;\n", .{});
+        _ = try writer.print(",\n    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
     }
 
     pub fn compute_output_shape(self: QLinearAveragePool) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearaveragepool.zig
@@ -305,7 +305,7 @@ pub const QLinearAveragePool = struct {
 
         _ = try writer.print(",\n        auto_pad_{s}", .{try utils.getSanitizedName(self.output_Y.name)});
         _ = try writer.print(",\n        {}", .{self.count_include_pad != 0});
-        _ = try writer.print(",\n    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
+        _ = try writer.print(",\n    ) catch return {d};\n", .{utils.getMathErrorReturn()});
     }
 
     pub fn compute_output_shape(self: QLinearAveragePool) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearconcat.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconcat.zig
@@ -253,7 +253,7 @@ pub const QLinearConcat = struct {
             \\        {s},
             \\        {},
             \\        &tensor_{s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             input_type_s, // 1. InputType (data)
             scale_type_s, // 2. ScaleType

--- a/src/IR_zant/op_union/operators/op_qlinearconcat.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconcat.zig
@@ -253,7 +253,7 @@ pub const QLinearConcat = struct {
             \\        {s},
             \\        {},
             \\        &tensor_{s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             input_type_s, // 1. InputType (data)
             scale_type_s, // 2. ScaleType
@@ -265,6 +265,7 @@ pub const QLinearConcat = struct {
             output_zero_point_string, // 8. output zero point
             self.axis, // 9. axis (i64)
             try utils.getSanitizedName(self.concat_result.name), // 10. output tensor
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_qlinearconv.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconv.zig
@@ -284,7 +284,7 @@ pub const QLinearConv = struct {
             \\        {s}, // dilations
             \\        {d}, // group
             \\        "{s}", // auto_pad
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             qlinearconv_impl,
             target_type, // InputType

--- a/src/IR_zant/op_union/operators/op_qlinearconv.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconv.zig
@@ -284,7 +284,7 @@ pub const QLinearConv = struct {
             \\        {s}, // dilations
             \\        {d}, // group
             \\        "{s}", // auto_pad
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             qlinearconv_impl,
             target_type, // InputType
@@ -307,6 +307,7 @@ pub const QLinearConv = struct {
             dilat_string, // dilations
             self.group, // group
             self.auto_pad, // auto_pad
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
@@ -148,7 +148,7 @@ pub const QLinearGlobalAveragePool = struct {
             \\        &tensor_{s},
             \\        {s},
             \\        {s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             tensor_X_string,
             tensor_X_scale_string,

--- a/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
@@ -146,7 +146,7 @@ pub const QLinearGlobalAveragePool = struct {
         try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_Y.name)});
         try writer.print("        {s},\n", .{tensor_Y_scale_string});
         try writer.print("        {s},\n", .{tensor_Y_zero_point_string});
-        try writer.print("    ) catch return -1;\n", .{});
+        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
     }
 
     pub fn compute_output_shape(self: QLinearGlobalAveragePool) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
@@ -139,14 +139,25 @@ pub const QLinearGlobalAveragePool = struct {
         }
 
         // Write the operation call
-        try writer.print("\n    tensMath.qlinearglobalaveragepool_lean(\n", .{});
-        try writer.print("        {s},\n", .{tensor_X_string});
-        try writer.print("        {s},\n", .{tensor_X_scale_string});
-        try writer.print("        {s},\n", .{tensor_X_zero_point_string});
-        try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_Y.name)});
-        try writer.print("        {s},\n", .{tensor_Y_scale_string});
-        try writer.print("        {s},\n", .{tensor_Y_zero_point_string});
-        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
+        try writer.print(
+            \\
+            \\    tensMath.qlinearglobalaveragepool_lean(
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        &tensor_{s},
+            \\        {s},
+            \\        {s},
+            \\    ) catch return -{d};
+        , .{
+            tensor_X_string,
+            tensor_X_scale_string,
+            tensor_X_zero_point_string,
+            try utils.getSanitizedName(self.output_Y.name),
+            tensor_Y_scale_string,
+            tensor_Y_zero_point_string,
+            utils.getMathErrorReturn(),
+        });
     }
 
     pub fn compute_output_shape(self: QLinearGlobalAveragePool) ![]usize {

--- a/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
@@ -185,7 +185,7 @@ pub const QLinearMatMul = struct {
             \\        &tensor_{s},
             \\        {s},
             \\        {s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             tensor_a_string,
             tensor_a_scale_string,

--- a/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
@@ -173,17 +173,31 @@ pub const QLinearMatMul = struct {
         }
 
         // Write the operation call
-        try writer.print("\n    tensMath.qlinearmatmul_lean(\n", .{});
-        try writer.print("        {s},\n", .{tensor_a_string});
-        try writer.print("        {s},\n", .{tensor_a_scale_string});
-        try writer.print("        {s},\n", .{tensor_a_zero_point_string});
-        try writer.print("        {s},\n", .{tensor_b_string});
-        try writer.print("        {s},\n", .{tensor_b_scale_string});
-        try writer.print("        {s},\n", .{tensor_b_zero_point_string});
-        try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_y.name)});
-        try writer.print("        {s},\n", .{tensor_y_scale_string});
-        try writer.print("        {s},\n", .{tensor_y_zero_point_string});
-        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
+        try writer.print(
+            \\
+            \\    tensMath.qlinearmatmul_lean(
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        {s},
+            \\        &tensor_{s},
+            \\        {s},
+            \\        {s},
+            \\    ) catch return -{d};
+        , .{
+            tensor_a_string,
+            tensor_a_scale_string,
+            tensor_a_zero_point_string,
+            tensor_b_string,
+            tensor_b_scale_string,
+            tensor_b_zero_point_string,
+            try utils.getSanitizedName(self.output_y.name),
+            tensor_y_scale_string,
+            tensor_y_zero_point_string,
+            utils.getMathErrorReturn(),
+        });
     }
 
     pub fn sobstitute_tensors(self: *QLinearMatMul, old_tensor: *TensorZant, new_tensor: *TensorZant) !void {

--- a/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearmatmul.zig
@@ -183,7 +183,7 @@ pub const QLinearMatMul = struct {
         try writer.print("        &tensor_{s},\n", .{try utils.getSanitizedName(self.output_y.name)});
         try writer.print("        {s},\n", .{tensor_y_scale_string});
         try writer.print("        {s},\n", .{tensor_y_zero_point_string});
-        try writer.print("    ) catch return -1;\n", .{});
+        try writer.print("    ) catch return -{d};\n", .{utils.getMathErrorReturn()});
     }
 
     pub fn sobstitute_tensors(self: *QLinearMatMul, old_tensor: *TensorZant, new_tensor: *TensorZant) !void {

--- a/src/IR_zant/op_union/operators/op_quantize.zig
+++ b/src/IR_zant/op_union/operators/op_quantize.zig
@@ -111,12 +111,13 @@ pub const Quantize = struct {
             \\        {s}, //input 
             \\        {s}, //&output 
             \\        quantScheme.ASYM, //hardcodedScheme
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input.ty.toString(),
             self.output.ty.toString(),
             input_tensor_string,
             output_tensor_string,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_quantize.zig
+++ b/src/IR_zant/op_union/operators/op_quantize.zig
@@ -111,7 +111,7 @@ pub const Quantize = struct {
             \\        {s}, //input 
             \\        {s}, //&output 
             \\        quantScheme.ASYM, //hardcodedScheme
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input.ty.toString(),
             self.output.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_quantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_quantizeLinear.zig
@@ -218,7 +218,7 @@ pub const QuantizeLinear = struct {
             \\                                 {},  // axis
             \\                                 {},  // block_size
             \\                                 &tensor_{s}, // y: output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.x.ty.toString(),
             self.y.ty.toString(),
@@ -229,6 +229,7 @@ pub const QuantizeLinear = struct {
             self.axis,
             self.block_size,
             try self.y.getNameSanitized(),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_quantizeLinear.zig
+++ b/src/IR_zant/op_union/operators/op_quantizeLinear.zig
@@ -218,7 +218,7 @@ pub const QuantizeLinear = struct {
             \\                                 {},  // axis
             \\                                 {},  // block_size
             \\                                 &tensor_{s}, // y: output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.x.ty.toString(),
             self.y.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_reduceMean.zig
+++ b/src/IR_zant/op_union/operators/op_reduceMean.zig
@@ -149,7 +149,7 @@ pub const ReduceMean = struct {
             \\        {s}, // axes
             \\        {s}, // keepdims
             \\        {s} // noop_with_empty_axes
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.data.ty.toString(), // type
             input_tensor_string, // input tensor

--- a/src/IR_zant/op_union/operators/op_reduceMean.zig
+++ b/src/IR_zant/op_union/operators/op_reduceMean.zig
@@ -149,7 +149,7 @@ pub const ReduceMean = struct {
             \\        {s}, // axes
             \\        {s}, // keepdims
             \\        {s} // noop_with_empty_axes
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.data.ty.toString(), // type
             input_tensor_string, // input tensor
@@ -157,6 +157,7 @@ pub const ReduceMean = struct {
             axes_str, // axes
             if (self.keepdims) "true" else "false", // keepdims
             if (self.noop_with_empty_axes) "true" else "false", // noop_with_empty_axes
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_relu.zig
+++ b/src/IR_zant/op_union/operators/op_relu.zig
@@ -88,11 +88,12 @@ pub const Relu = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.ReLU_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.ReLU_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.output_Y.ty.toString(),
             tensor_A_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_relu.zig
+++ b/src/IR_zant/op_union/operators/op_relu.zig
@@ -88,7 +88,7 @@ pub const Relu = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.ReLU_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.ReLU_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.output_Y.ty.toString(),
             tensor_A_string,

--- a/src/IR_zant/op_union/operators/op_reshape.zig
+++ b/src/IR_zant/op_union/operators/op_reshape.zig
@@ -139,7 +139,7 @@ pub const Reshape = struct {
             try shape_slice_code.writer(allocator).print(
                 \\    // Convert shape tensor data to isize slice
                 \\    // Pass the local allocator to the utils function
-                \\    const shape_slice_{s} = utils.sliceToIsizeSlice(allocator, {s}.data) catch return -{d};
+                \\    const shape_slice_{s} = utils.sliceToIsizeSlice(allocator, {s}.data) catch return {d};
                 \\    defer allocator.free(shape_slice_{s}); // Free the runtime allocated slice
             , .{
                 output_sanitized_name, // Use output name for uniqueness
@@ -171,7 +171,7 @@ pub const Reshape = struct {
             \\        {s}, // Pre-built shape slice argument
             \\        {s}, // Format boolean correctly
             \\        {s}, // Pre-built output tensor argument
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             shape_slice_code.items, // Arg 1 for shape code
             self.data.ty.toString(), // Arg 2 for input type

--- a/src/IR_zant/op_union/operators/op_reshape.zig
+++ b/src/IR_zant/op_union/operators/op_reshape.zig
@@ -139,11 +139,12 @@ pub const Reshape = struct {
             try shape_slice_code.writer(allocator).print(
                 \\    // Convert shape tensor data to isize slice
                 \\    // Pass the local allocator to the utils function
-                \\    const shape_slice_{s} = utils.sliceToIsizeSlice(allocator, {s}.data) catch return -1;
+                \\    const shape_slice_{s} = utils.sliceToIsizeSlice(allocator, {s}.data) catch return -{d};
                 \\    defer allocator.free(shape_slice_{s}); // Free the runtime allocated slice
             , .{
                 output_sanitized_name, // Use output name for uniqueness
                 shape_tensor_name,
+                utils.getMathErrorReturn(), // Error code for math errors
                 output_sanitized_name,
             });
         }
@@ -170,7 +171,7 @@ pub const Reshape = struct {
             \\        {s}, // Pre-built shape slice argument
             \\        {s}, // Format boolean correctly
             \\        {s}, // Pre-built output tensor argument
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             shape_slice_code.items, // Arg 1 for shape code
             self.data.ty.toString(), // Arg 2 for input type
@@ -178,6 +179,7 @@ pub const Reshape = struct {
             shape_slice_arg, // Arg 4 for shape slice
             if (self.allowzer0) "true" else "false", // Arg 5 for allowzero
             output_tensor_arg, // Arg 6 for output tensor
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_resize.zig
+++ b/src/IR_zant/op_union/operators/op_resize.zig
@@ -223,7 +223,7 @@ pub const Resize = struct {
             \\      {s}, //sizes: ?[]const usize
             \\      "{s}", //coordinate_transformation_mode: []const u8
             \\      &tensor_{s}, //output_tensor: *Tensor(T)
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         ,
             .{
                 self.input_X.ty.toString(), // type
@@ -233,6 +233,7 @@ pub const Resize = struct {
                 data_sizes_string,
                 self.coordinate_transformation_mode,
                 try utils.getSanitizedName(self.output_Y.name), //output
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_resize.zig
+++ b/src/IR_zant/op_union/operators/op_resize.zig
@@ -223,7 +223,7 @@ pub const Resize = struct {
             \\      {s}, //sizes: ?[]const usize
             \\      "{s}", //coordinate_transformation_mode: []const u8
             \\      &tensor_{s}, //output_tensor: *Tensor(T)
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         ,
             .{
                 self.input_X.ty.toString(), // type

--- a/src/IR_zant/op_union/operators/op_shape.zig
+++ b/src/IR_zant/op_union/operators/op_shape.zig
@@ -102,13 +102,14 @@ pub const Shape = struct {
             \\        {s}, //start
             \\        {s}, //end
             \\        &tensor_{s}, //output shape tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.data.ty.toString(),
             tensor_data_string,
             if (self.start) |s| try std.fmt.allocPrint(allocator, "{}", .{s}) else "null",
             if (self.end) |e| try std.fmt.allocPrint(allocator, "{}", .{e}) else "null",
             try utils.getSanitizedName(self.shape.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_shape.zig
+++ b/src/IR_zant/op_union/operators/op_shape.zig
@@ -102,7 +102,7 @@ pub const Shape = struct {
             \\        {s}, //start
             \\        {s}, //end
             \\        &tensor_{s}, //output shape tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.data.ty.toString(),
             tensor_data_string,

--- a/src/IR_zant/op_union/operators/op_sigmoid.zig
+++ b/src/IR_zant/op_union/operators/op_sigmoid.zig
@@ -86,12 +86,13 @@ pub const Sigmoid = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         ,
             .{
                 self.input_X.ty.toString(),
                 tensor_X_string,
                 try utils.getSanitizedName(self.output_Y.name),
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_sigmoid.zig
+++ b/src/IR_zant/op_union/operators/op_sigmoid.zig
@@ -86,7 +86,7 @@ pub const Sigmoid = struct {
             \\      {s},
             \\      {s},
             \\      &tensor_{s},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         ,
             .{
                 self.input_X.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_slice.zig
+++ b/src/IR_zant/op_union/operators/op_slice.zig
@@ -169,7 +169,7 @@ pub const Slice = struct {
             \\        {s}, //axes
             \\        {s}, //steps
             \\        &tensor_{s}, //output
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input.ty.toString(), //type
             self.starts.ty.toString(), //type 1
@@ -179,6 +179,7 @@ pub const Slice = struct {
             tensor_axes_string, //axes
             tensor_steps_string, //steps
             try self.output.getNameSanitized(),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_slice.zig
+++ b/src/IR_zant/op_union/operators/op_slice.zig
@@ -169,7 +169,7 @@ pub const Slice = struct {
             \\        {s}, //axes
             \\        {s}, //steps
             \\        &tensor_{s}, //output
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input.ty.toString(), //type
             self.starts.ty.toString(), //type 1

--- a/src/IR_zant/op_union/operators/op_softmax.zig
+++ b/src/IR_zant/op_union/operators/op_softmax.zig
@@ -102,13 +102,14 @@ pub const Softmax = struct {
             \\        {s}, // input tensor
             \\        &tensor_{s}, // output tensor
             \\        {},
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
             \\
         , .{
             self.output_Y.ty.toString(),
             tensor_input_string,
             try utils.getSanitizedName(self.output_Y.name),
             self.axis,
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_softmax.zig
+++ b/src/IR_zant/op_union/operators/op_softmax.zig
@@ -102,7 +102,7 @@ pub const Softmax = struct {
             \\        {s}, // input tensor
             \\        &tensor_{s}, // output tensor
             \\        {},
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
             \\
         , .{
             self.output_Y.ty.toString(),

--- a/src/IR_zant/op_union/operators/op_split.zig
+++ b/src/IR_zant/op_union/operators/op_split.zig
@@ -170,7 +170,7 @@ pub const Split = struct {
                 \\            {d}, // axis
                 \\            {s}, // split sizes
                 \\            &split_outputs_slice // all outputs
-                \\        ) catch return -{d};
+                \\        ) catch return {d};
                 \\    }}
             , .{
                 self.num_outputs,
@@ -206,7 +206,7 @@ pub const Split = struct {
                 \\            {d}, // axis
                 \\            uniform_sizes[0..], // uniform split sizes
                 \\            &split_outputs_slice // all outputs
-                \\        ) catch return -{d};
+                \\        ) catch return {d};
                 \\    }}
             , .{
                 self.num_outputs,

--- a/src/IR_zant/op_union/operators/op_split.zig
+++ b/src/IR_zant/op_union/operators/op_split.zig
@@ -170,7 +170,7 @@ pub const Split = struct {
                 \\            {d}, // axis
                 \\            {s}, // split sizes
                 \\            &split_outputs_slice // all outputs
-                \\        ) catch return -1;
+                \\        ) catch return -{d};
                 \\    }}
             , .{
                 self.num_outputs,
@@ -180,6 +180,7 @@ pub const Split = struct {
                 tensor_input_string,
                 self.axis,
                 split_sizes_string,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         } else {
             // Without split sizes - uniform split
@@ -205,7 +206,7 @@ pub const Split = struct {
                 \\            {d}, // axis
                 \\            uniform_sizes[0..], // uniform split sizes
                 \\            &split_outputs_slice // all outputs
-                \\        ) catch return -1;
+                \\        ) catch return -{d};
                 \\    }}
             , .{
                 self.num_outputs,
@@ -217,6 +218,7 @@ pub const Split = struct {
                 self.input.ty.toString(),
                 tensor_input_string,
                 self.axis,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
         }
     }

--- a/src/IR_zant/op_union/operators/op_sqrt.zig
+++ b/src/IR_zant/op_union/operators/op_sqrt.zig
@@ -85,11 +85,12 @@ pub const Sqrt = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.sqrt_lean({s}, {s}, &tensor_{s}) catch return -1;
+            \\    tensMath.sqrt_lean({s}, {s}, &tensor_{s}) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_sqrt.zig
+++ b/src/IR_zant/op_union/operators/op_sqrt.zig
@@ -85,7 +85,7 @@ pub const Sqrt = struct {
         _ = try writer.print(
             \\
             \\
-            \\    tensMath.sqrt_lean({s}, {s}, &tensor_{s}) catch return -{d};
+            \\    tensMath.sqrt_lean({s}, {s}, &tensor_{s}) catch return {d};
         , .{
             self.input_X.ty.toString(),
             input_tensor_string,

--- a/src/IR_zant/op_union/operators/op_squeeze.zig
+++ b/src/IR_zant/op_union/operators/op_squeeze.zig
@@ -117,11 +117,12 @@ pub const Squeeze = struct {
             \\        {s},
             \\        {s}, // Input tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_data.ty.toString(),
             tensor_data_string,
             try utils.getSanitizedName(self.output.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_squeeze.zig
+++ b/src/IR_zant/op_union/operators/op_squeeze.zig
@@ -117,7 +117,7 @@ pub const Squeeze = struct {
             \\        {s},
             \\        {s}, // Input tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_data.ty.toString(),
             tensor_data_string,

--- a/src/IR_zant/op_union/operators/op_sub.zig
+++ b/src/IR_zant/op_union/operators/op_sub.zig
@@ -152,7 +152,7 @@ pub const Sub = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 a_type,
@@ -167,6 +167,7 @@ pub const Sub = struct {
                 prefix,
                 a_name,
                 a_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_a_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", a_name, "_A_casted)" });
             need_free_a = true;
@@ -183,7 +184,7 @@ pub const Sub = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -1;
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -{d};
                 \\
             , .{
                 b_type,
@@ -198,6 +199,7 @@ pub const Sub = struct {
                 prefix,
                 b_name,
                 b_name,
+                utils.getMathErrorReturn(), // Error code for math errors
             });
             final_b_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "@constCast(&tensor_", b_name, "_B_casted)" });
             need_free_b = true;
@@ -212,13 +214,14 @@ pub const Sub = struct {
             \\        {s}, // input A
             \\        {s}, // input B
             \\        &tensor_{s} // output Y
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             target_type,
             target_type,
             final_a_string,
             final_b_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_sub.zig
+++ b/src/IR_zant/op_union/operators/op_sub.zig
@@ -152,7 +152,7 @@ pub const Sub = struct {
                 \\    // Cast input A from {s} to {s}
                 \\    var tensor_{s}_A_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_A_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_A_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 a_type,
@@ -184,7 +184,7 @@ pub const Sub = struct {
                 \\    // Cast input B from {s} to {s}
                 \\    var tensor_{s}_B_casted = Tensor({s}).fromShape(&allocator, @constCast({s}tensor_{s}.shape)) catch return -2;
                 \\    defer tensor_{s}_B_casted.deinit();
-                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return -{d};
+                \\    tensMath.cast_lean({s}, {s}, @constCast(&{s}tensor_{s}), &tensor_{s}_B_casted, zant.onnx.DataType.FLOAT) catch return {d};
                 \\
             , .{
                 b_type,
@@ -214,7 +214,7 @@ pub const Sub = struct {
             \\        {s}, // input A
             \\        {s}, // input B
             \\        &tensor_{s} // output Y
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             target_type,
             target_type,

--- a/src/IR_zant/op_union/operators/op_tanh.zig
+++ b/src/IR_zant/op_union/operators/op_tanh.zig
@@ -101,11 +101,12 @@ pub const Tanh = struct {
             \\        {s},
             \\        {s}, // input tensor
             \\        &tensor_{s} // output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_tanh.zig
+++ b/src/IR_zant/op_union/operators/op_tanh.zig
@@ -101,7 +101,7 @@ pub const Tanh = struct {
             \\        {s},
             \\        {s}, // input tensor
             \\        &tensor_{s} // output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,

--- a/src/IR_zant/op_union/operators/op_topk.zig
+++ b/src/IR_zant/op_union/operators/op_topk.zig
@@ -145,7 +145,7 @@ pub const TopK = struct {
             \\            {d},
             \\            {s},
             \\            {s},
-            \\        ) catch return -{d};
+            \\        ) catch return {d};
             \\        _ = topk_result;
             \\    }}
         ,

--- a/src/IR_zant/op_union/operators/op_topk.zig
+++ b/src/IR_zant/op_union/operators/op_topk.zig
@@ -145,7 +145,7 @@ pub const TopK = struct {
             \\            {d},
             \\            {s},
             \\            {s},
-            \\        ) catch return -1;
+            \\        ) catch return -{d};
             \\        _ = topk_result;
             \\    }}
         ,
@@ -158,6 +158,7 @@ pub const TopK = struct {
                 self.axis,
                 if (self.largest) "true" else "false",
                 if (self.sorted) "true" else "false",
+                utils.getMathErrorReturn(), // Error code for math errors
             },
         );
     }

--- a/src/IR_zant/op_union/operators/op_transpose.zig
+++ b/src/IR_zant/op_union/operators/op_transpose.zig
@@ -118,7 +118,7 @@ pub const Transpose = struct {
             \\        {s}, // perm array
             \\        &tensor_{s}, // output 
             \\        allocator,
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,

--- a/src/IR_zant/op_union/operators/op_transpose.zig
+++ b/src/IR_zant/op_union/operators/op_transpose.zig
@@ -118,12 +118,13 @@ pub const Transpose = struct {
             \\        {s}, // perm array
             \\        &tensor_{s}, // output 
             \\        allocator,
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,
             perm_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/op_union/operators/op_unsqueeze.zig
+++ b/src/IR_zant/op_union/operators/op_unsqueeze.zig
@@ -125,7 +125,7 @@ pub const Unsqueeze = struct {
             \\        {s}, // Input tensor
             \\        {s}, // Axes tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -{d};
+            \\    ) catch return {d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,

--- a/src/IR_zant/op_union/operators/op_unsqueeze.zig
+++ b/src/IR_zant/op_union/operators/op_unsqueeze.zig
@@ -125,12 +125,13 @@ pub const Unsqueeze = struct {
             \\        {s}, // Input tensor
             \\        {s}, // Axes tensor
             \\        &tensor_{s} // Output tensor
-            \\    ) catch return -1;
+            \\    ) catch return -{d};
         , .{
             self.input_X.ty.toString(),
             tensor_X_string,
             axes_string,
             try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
         });
     }
 

--- a/src/IR_zant/utils.zig
+++ b/src/IR_zant/utils.zig
@@ -24,7 +24,7 @@ pub const TensorCategory = tensorZant_lib.TensorCategory;
 const DType = zant.uops.DType;
 
 // --- error codes ---
-var math_error_counter: i32 = 100;
+var math_error_counter: i32 = -100;
 
 pub fn getValueInfoTensorFromGraphInfo(name: []const u8, protoGraph: *GraphProto) ?*ValueInfoProto {
     for (protoGraph.value_info) |vi| {
@@ -619,6 +619,6 @@ pub fn from_NHWC_to_NCHW(alloc: std.mem.Allocator, tensor_nhwc: *TensorZant) !*T
 
 // Returns the error code after incrementing the global counter
 pub fn getMathErrorReturn() i32 {
-    math_error_counter += 1;
+    math_error_counter -= 1;
     return math_error_counter;
 }

--- a/src/IR_zant/utils.zig
+++ b/src/IR_zant/utils.zig
@@ -23,6 +23,9 @@ pub const TensorCategory = tensorZant_lib.TensorCategory;
 // --- uops ---
 const DType = zant.uops.DType;
 
+// --- error codes ---
+var math_error_counter: i32 = 100;
+
 pub fn getValueInfoTensorFromGraphInfo(name: []const u8, protoGraph: *GraphProto) ?*ValueInfoProto {
     for (protoGraph.value_info) |vi| {
         if (std.mem.eql(u8, vi.name.?, name)) {
@@ -612,4 +615,10 @@ pub fn from_NHWC_to_NCHW(alloc: std.mem.Allocator, tensor_nhwc: *TensorZant) !*T
     alloc.destroy(tensor_nhwc);
 
     return result;
+}
+
+// Returns the error code after incrementing the global counter
+pub fn getMathErrorReturn() i32 {
+    math_error_counter += 1;
+    return math_error_counter;
 }

--- a/src/IR_zant/utils.zig
+++ b/src/IR_zant/utils.zig
@@ -24,7 +24,7 @@ pub const TensorCategory = tensorZant_lib.TensorCategory;
 const DType = zant.uops.DType;
 
 // --- error codes ---
-var math_error_counter: i32 = -100;
+var math_operator_counter: i32 = -100; // Counts how many calls to math operators happen
 
 pub fn getValueInfoTensorFromGraphInfo(name: []const u8, protoGraph: *GraphProto) ?*ValueInfoProto {
     for (protoGraph.value_info) |vi| {
@@ -617,8 +617,8 @@ pub fn from_NHWC_to_NCHW(alloc: std.mem.Allocator, tensor_nhwc: *TensorZant) !*T
     return result;
 }
 
-// Returns the error code after incrementing the global counter
+// Returns the error code after derementing the global counter
 pub fn getMathErrorReturn() i32 {
-    math_error_counter -= 1;
-    return math_error_counter;
+    math_operator_counter -= 1;
+    return math_operator_counter;
 }

--- a/src/codegen/cg_v1/predict/templates.zig
+++ b/src/codegen/cg_v1/predict/templates.zig
@@ -27,9 +27,10 @@ pub fn emitFunctionSignature(writer: *std.Io.Writer, do_export: bool) !void {
         \\
         \\ // return codes:
         \\ //  0 : everything good
-        \\ // -1 : something went wrong in the mathematical operations
         \\ // -2 : something went wrong in the initialization phase
         \\ // -3 : something went wrong in the output/return phase
+        \\ // -100 onwards : something went wrong in the mathematical operations, the specific error 
+        \\ //              code indicates which operation failed (e.g., -101 means first operation failed, -102 second, etc.)
         \\pub {s} fn predict (
         \\    input: [*]T_in,
         \\    input_shape: [*]u32,


### PR DESCRIPTION
# Error management in codegenerated file–issue #496 

## Description

Replace the hardcoded -1 runtime error return in predict() with a progressive negative error code system–starting from -101–that identifies the which math operation failed during inference. E.g. if the return code is -101 it means that the first operation failed, if the return code is -102 the second one, etc.
Previously, all core-level runtime errors returned -1, making it impossible to determine which math operation caused the failure. This significantly reduced observability and made debugging inference issues difficult.
Each runtime failure now returns a distinct negative value corresponding to the operation that triggered the error. This enables precise identification of failure points during inference and greatly improves debuggability.

**Related Issue:** Closes #496 

## Type of Change

Please mark the options that are relevant:

- [x] Bug fix 🐛
- [x] New feature 🚀
- [ ] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
     > no extra tests were needed
- [ ] All new and existing tests pass.
     > some existing tests are already not passing

## Testing

To test this feature simply follow the steps to generate the `lib_my_model.zig` of any model (I used best, beer, and mnist-8), which can be found in [ZANT_CLI](/Z-Ant/docs/ZANT_CLI.md). They are also reported here:
```bash
./zant input_setter --model my_model --shape 1,3,224,224 #use https://netron.app/ to see the input shape
# or, if the model input is already well defined you can run this:
./zant shape_thief --model my_model #shape_thief is in Beta version

# Generate test data
./zant user_tests_gen --model my_model

# --- GENERATING THE LIBRARY and TESTS ---
# Generate code for a specific model
zig build lib-gen -Dmodel="my_model" -Denable_user_tests [ -Ddo_export -Dxip -Dfuse -Dlog -Dcomm ... ]

# YOU CAN STOP HERE FOR THIS SPECIFIC TESTING

# Test the generated code
zig build lib-test -Dmodel="my_model" -Denable_user_tests [ -Dfuse -Ddo_export -Dlog -Dcomm ... ]

# Build the static library
zig build lib -Dmodel="my_model" [-Doptimize= [ ReleaseSmall, ReleaseFast ] -Dtarget=... -Dcpu=...]
```
After generating the `lib_my_model.zig` file–which can be found under `generated/my_model`–simply check that all codegenerated calls to the Zant core have different return error starting from -101 onwards.

## Suggested issues

- Some fused operations miss the codegen, namely: `fused_2Dequant_Add_Quant`, `fused_Conv_Sigmoid_Mul`, `fused_Dequant_Pad_Quant_QLinConv`, `fused_Dequant_Quant`, `fused_Pad_Conv`, `fused_Quant_Dequant`;
- When `op_split` codegenerates its call to `tensMath.split_lean` it passes an `i64` to the second to last argument, which is `[]const usize`.
   >  <img width="767" height="192" alt="image" src="https://github.com/user-attachments/assets/595a62cf-8d3c-4712-985b-fa29a13e6984" />
