### PR TITLE
feat: add abs operation

### DIFF
--- a/src/codegen/IR_zant/onnx/onnxOperator.zig
+++ b/src/codegen/IR_zant/onnx/onnxOperator.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const OnnxOperator = enum {
+    ABS,
     ADD,
     AVERAGEPOOL,
     BATCHNORMALIZATION,
@@ -72,6 +73,7 @@ pub fn isQlinear(op_type: OnnxOperator) bool {
 }
 
 pub fn fromString(op_type: []const u8) !OnnxOperator {
+    if (std.mem.eql(u8, op_type, "Abs")) return .ABS;
     if (std.mem.eql(u8, op_type, "Add")) return .ADD;
     if (std.mem.eql(u8, op_type, "AveragePool")) return .AVERAGEPOOL;
     if (std.mem.eql(u8, op_type, "BatchNormalization")) return .BATCHNORMALIZATION;

--- a/src/codegen/IR_zant/op_union/op_union.zig
+++ b/src/codegen/IR_zant/op_union/op_union.zig
@@ -14,6 +14,7 @@ const NodeZant = nodeZant.NodeZant;
 
 pub const Op_union = union(enum) {
     // ------------- atomic operations
+    abs: operators.Abs,
     add: operators.Add,
     averagePool: operators.AveragePool,
     batchNormalization: operators.BatchNormalization,
@@ -92,6 +93,7 @@ pub const Op_union = union(enum) {
     pub fn init(nodeProto: *NodeProto) !Op_union {
         const op_type = nodeProto.op_type;
         return switch (op_type) {
+            .ABS => Op_union{ .abs = try operators.Abs.init(nodeProto) },
             .ADD => Op_union{ .add = try operators.Add.init(nodeProto) },
             .AVERAGEPOOL => Op_union{ .averagePool = try operators.AveragePool.init(nodeProto) },
             .BATCHNORMALIZATION => Op_union{ .batchNormalization = try operators.BatchNormalization.init(nodeProto) },

--- a/src/codegen/IR_zant/op_union/operators/op_abs/README.md
+++ b/src/codegen/IR_zant/op_union/operators/op_abs/README.md
@@ -1,0 +1,13 @@
+# Abs
+
+For the full specification of this operator, refer to the official ONNX documentation:
+
+https://onnx.ai/onnx/operators/onnx__Abs.html
+
+Please look up the standard for input/output definitions, type constraints, and attribute details before modifying this implementation.
+
+## Files
+
+- `op_abs.zig` — IR operator struct: parses the ONNX node, performs shape inference, and emits the codegen call via `write_op`.
+- `utils_abs.zig` — shape-inference and attribute-parsing helpers used by the IR layer.
+- `zant_abs.zig` — runtime math implementation (lean and standard variants) called by generated code.

--- a/src/codegen/IR_zant/op_union/operators/op_abs/op_abs.zig
+++ b/src/codegen/IR_zant/op_union/operators/op_abs/op_abs.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const allocator = std.heap.page_allocator;
+const IR_zant = @import("IR_zant");
+
+// --- onnx ---
+const onnx = IR_zant.onnx;
+const ModelProto = onnx.ModelProto;
+const GraphProto = onnx.GraphProto;
+const NodeProto = onnx.NodeProto;
+const TensorProto = onnx.TensorProto;
+
+// --- zant ---
+const tensorZant_lib = IR_zant.tensorZant_lib;
+const TensorZant = tensorZant_lib.TensorZant;
+const TensorCategory = tensorZant_lib.TensorCategory;
+
+const tensorMath = IR_zant.core.math_standard;
+
+const utils = IR_zant.utils;
+
+// https://onnx.ai/onnx/operators/onnx__Abs.html
+// INPUTS:
+//      - X (heterogeneous) - T: Input tensor
+// OUTPUTS:
+//      - Y (heterogeneous) - T: Output tensor with absolute value of input elements
+pub const Abs = struct {
+    input_X: *TensorZant,
+    output_Y: *TensorZant,
+
+    pub fn init(nodeProto: *NodeProto) !Abs {
+        const input_X = if (tensorZant_lib.tensorMap.getPtr(nodeProto.input[0])) |ptr| ptr else return error.input_X_notFound;
+        const output_Y = if (tensorZant_lib.tensorMap.getPtr(nodeProto.output[0])) |ptr| ptr else return error.output_Y_notFound;
+
+        //set the output type:
+        if (output_Y.ty == tensorZant_lib.TensorType.undefined) output_Y.ty = input_X.ty;
+
+        return Abs{
+            .input_X = input_X,
+            .output_Y = output_Y,
+        };
+    }
+
+    pub fn get_output_shape(self: Abs) []usize {
+        return self.output_Y.getShape();
+    }
+
+    pub fn get_input_tensors(self: Abs) ![]*TensorZant {
+        var input_tensors: std.ArrayList(*TensorZant) = .empty;
+        defer input_tensors.deinit(allocator);
+
+        // Append the single input tensor X
+        try input_tensors.append(allocator, self.input_X);
+
+        return input_tensors.toOwnedSlice(allocator);
+    }
+
+    pub fn get_output_tensors(self: Abs) ![]*TensorZant {
+        var output_tensors: std.ArrayList(*TensorZant) = .empty;
+        defer output_tensors.deinit(allocator);
+
+        // Append the single output tensor Y
+        try output_tensors.append(allocator, self.output_Y);
+
+        return output_tensors.toOwnedSlice(allocator);
+    }
+
+    pub fn write_op(self: Abs, writer: *std.Io.Writer) !void {
+        var input_tensor_string: []u8 = undefined;
+        defer allocator.free(input_tensor_string);
+
+        if (self.input_X.tc == TensorCategory.INITIALIZER) {
+            input_tensor_string = try std.mem.concat(allocator, u8, &[_][]const u8{
+                "@constCast(&param_lib.tensor_",
+                try utils.getSanitizedName(self.input_X.name),
+                ")",
+            });
+        } else {
+            input_tensor_string = try std.mem.concat(allocator, u8, &[_][]const u8{ "&tensor_", try utils.getSanitizedName(self.input_X.name) });
+        }
+
+        _ = try writer.print(
+            \\
+            \\
+            \\    tensMath.abs_lean({s}, {s}, &tensor_{s}) catch return {d};
+        , .{
+            self.input_X.ty.toString(),
+            input_tensor_string,
+            try utils.getSanitizedName(self.output_Y.name),
+            utils.getMathErrorReturn(), // Error code for math errors
+        });
+    }
+
+    pub fn compute_output_shape(self: Abs) []usize {
+        var output_shape: []usize = undefined;
+        output_shape = try tensorMath.get_abs_output_shape(self.input_X.get_shape());
+        self.output_Y.shape = output_shape;
+        return output_shape;
+    }
+
+    pub fn print(self: Abs) void { // TODO
+        std.debug.print("\n Abs:\n {any}", .{self});
+    }
+
+    pub fn sobstitute_tensors(self: *Abs, old_tensor: *TensorZant, new_tensor: *TensorZant) !void {
+        if (self.input_X == old_tensor) {
+            self.input_X = new_tensor;
+            return;
+        }
+        if (self.output_Y == old_tensor) {
+            self.output_Y = new_tensor;
+            return;
+        }
+        return error.TensorNotFound;
+    }
+};

--- a/src/codegen/IR_zant/op_union/operators/op_abs/utils_abs.zig
+++ b/src/codegen/IR_zant/op_union/operators/op_abs/utils_abs.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const IR_zant = @import("IR_zant");
+const pkg_allocator = IR_zant.pkg_allocator.allocator;
+
+pub fn get_abs_output_shape(input_shape: []const usize) ![]usize {
+    // Allocate and copy the input shape
+    const output_shape = try pkg_allocator.alloc(usize, input_shape.len);
+    errdefer pkg_allocator.free(output_shape);
+
+    std.mem.copyForwards(usize, output_shape, input_shape);
+
+    return output_shape;
+}

--- a/src/codegen/IR_zant/op_union/operators/op_abs/zant_abs.zig
+++ b/src/codegen/IR_zant/op_union/operators/op_abs/zant_abs.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const IR_zant = @import("IR_zant");
+const Tensor = IR_zant.core.tensor.Tensor; // Import Tensor type
+
+pub const utils = @import("utils_abs.zig");
+
+// --------- standard ABS
+/// Compute element-wise the absolute value of the given tensor.
+pub fn abs(comptime T: anytype, input: *Tensor(T)) !Tensor(T) {
+    // Verify that T is among the supported types:
+    // tensor(bfloat16), tensor(double), tensor(float),
+    // tensor(float16), tensor(int16), tensor(int32),
+    // tensor(int64), tensor(int8), tensor(uint16),
+    // tensor(uint32), tensor(uint64), tensor(uint8)
+    comptime if (!(std.meta.eql(T, f64) or std.meta.eql(T, f32) or std.meta.eql(T, f16) or std.meta.eql(T, f16) or std.meta.eql(T, i16) or std.meta.eql(T, i32) or std.meta.eql(T, i64) or std.meta.eql(T, i8) or std.meta.eql(T, u16) or std.meta.eql(T, u32) or std.meta.eql(T, u64) or std.meta.eql(T, u8))) {
+        @compileError("Unsupported type in abs_lean");
+    };
+
+    // Allocate output tensor with the same shape as the input
+    var result = try Tensor(T).fromShape(input.allocator, input.shape);
+
+    // Perform element-wise abs computation
+    try abs_lean(T, input, &result);
+
+    return result;
+}
+
+// --------- lean ABS
+pub inline fn abs_lean(comptime T: anytype, input: *Tensor(T), result: *Tensor(T)) !void {
+    for (input.data, result.data) |x, *y| {
+        if (std.math.isNan(x) or std.math.isInf(x)) {
+            y.* = x;
+        } else {
+            y.* = @abs(x);
+        }
+    }
+}

--- a/src/codegen/IR_zant/op_union/operators/operators.zig
+++ b/src/codegen/IR_zant/op_union/operators/operators.zig
@@ -1,3 +1,4 @@
+pub const Abs = @import("op_abs/op_abs.zig").Abs;
 pub const Add = @import("op_add/op_add.zig").Add;
 pub const AveragePool = @import("op_averagePool/op_averagePool.zig").AveragePool;
 pub const BatchNormalization = @import("op_batchNormalization/op_batchNormalization.zig").BatchNormalization;

--- a/src/codegen/IR_zant/op_union/operators/zant_math_standard.zig
+++ b/src/codegen/IR_zant/op_union/operators/zant_math_standard.zig
@@ -174,6 +174,14 @@ pub const get_topk_output_shape = op_topk_utils.get_topk_output_shape;
 
 // ===================== element-wise math =====================
 
+//---abs
+const op_abs = @import("op_abs/zant_abs.zig");
+const op_abs_utils = @import("op_abs/utils_abs.zig");
+
+pub const abs = op_abs.abs;
+pub const abs_lean = op_abs.abs_lean;
+pub const get_abs_output_shape = op_abs_utils.get_abs_output_shape;
+
 //---add
 const op_add = @import("op_add/zant_add.zig");
 const op_add_utils = @import("op_add/utils_add.zig");

--- a/tests/CodeGen/Python-ONNX/available_operations.txt
+++ b/tests/CodeGen/Python-ONNX/available_operations.txt
@@ -1,5 +1,6 @@
 # The operation marked with "#" has a bug or must be implemented
 # Remember to launch first of all : python3 tests/CodeGen/Python-ONNX/onnx_gen.py  to generate the models
+Abs
 Add  
 AveragePool
 BatchNormalization  

--- a/tests/CodeGen/Python-ONNX/onnx_gen.py
+++ b/tests/CodeGen/Python-ONNX/onnx_gen.py
@@ -75,6 +75,7 @@ from operators.qLinearConcat import generate_qlinearconcat_model
 from operators.qLinearMul import generate_qlinearmul_model
 from operators.qLinearSoftmax import generate_qlinearsoftmax_model
 from operators.topK import generate_topk_model
+from operators.abs import generate_abs_model
 
 
 def random_shape(rank, min_dim=1, max_dim=10):
@@ -157,6 +158,7 @@ def generate_fuzz_model(op_name):
         "ConvInteger": generate_convinteger_model,
         "PadConv": generate_padconv_model,
         "Pow": generate_pow_model,
+        "Abs": generate_abs_model,
     }
     
     if op_name in operator_generators:

--- a/tests/CodeGen/Python-ONNX/operators/abs.py
+++ b/tests/CodeGen/Python-ONNX/operators/abs.py
@@ -1,0 +1,24 @@
+import numpy as np
+import random
+from onnx import helper, TensorProto
+
+
+def generate_abs_model(input_names, output_names):
+    """
+    Generates a Abs operator model.
+    """
+    initializers = []
+    
+    # Operatori a singolo input con forma casuale (rank=4)
+    shape = [1, random.randint(1,4), random.randint(10,50), random.randint(10,50)]
+    data = np.random.randn(*shape).astype(np.float32)
+    init_tensor = helper.make_tensor(input_names[0], TensorProto.FLOAT, shape, data.flatten().tolist())
+    initializers.append(init_tensor)
+
+    input_info = helper.make_tensor_value_info("useless_input", TensorProto.FLOAT, shape)
+    output_info = helper.make_tensor_value_info(output_names[0], TensorProto.FLOAT, shape)
+
+    node = helper.make_node("Abs", inputs=[input_names[0]], outputs=[output_names[0]], 
+                            name=f"Abs_node")
+    metadata = {"input_shapes": [shape], "output_shapes": [shape]}
+    return [input_info], output_info, [node], initializers, metadata


### PR DESCRIPTION
# Abs operation

- create abs node
- create abs codegen
- add abs to available operators
- add python script to test operation

Tested the changes with all the other operators to ensure nothing breaks:
- `./zant onnx_gen`
- `zig build op-codegen-gen`
- `zig build op-codegen-test`